### PR TITLE
feat: implement native macOS BG3 Mod Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved
+
+# Xcode
+*.xcodeproj/
+*.xcworkspace/
+xcuserdata/
+DerivedData/
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+*.xccheckout
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# macOS
+.DS_Store
+*.swp
+*~.nib

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "BG3MacModManager",
+    platforms: [
+        .macOS(.v13)
+    ],
+    targets: [
+        .executableTarget(
+            name: "BG3MacModManager",
+            path: "Sources/BG3MacModManager",
+            swiftSettings: [
+                .unsafeFlags(["-Xfrontend", "-enable-upcoming-feature", "StrictConcurrency"], .when(configuration: .debug))
+            ]
+        ),
+        .testTarget(
+            name: "BG3MacModManagerTests",
+            dependencies: ["BG3MacModManager"],
+            path: "Tests/BG3MacModManagerTests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,153 @@
-# A macOS Mod Manager for Baldur's Gate 3
+# BG3 Mac Mod Manager
+
+A native macOS application for managing Baldur's Gate 3 mods, inspired by [LaughingLeader's BG3 Mod Manager](https://github.com/LaughingLeader/BG3ModManager) for Windows.
+
+Built with Swift and SwiftUI, this tool provides a first-class macOS experience for installing, organizing, and managing BG3 mods — including full integration with [bg3se-macos](https://github.com/tdimino/bg3se-macos) (Script Extender for macOS).
+
+## Features
+
+### Mod Management
+- **Discover & import mods** — scans your Mods folder and imports `.pak` files (or ZIPs containing them)
+- **Drag-and-drop load order** — reorder active mods to control load priority
+- **Activate / deactivate** — toggle mods between active and inactive with a click
+- **Rich metadata** — displays name, author, version, description, UUID, dependencies, and tags parsed from `info.json` or `meta.lsx` inside `.pak` files
+- **Dependency warnings** — flags mods with missing dependencies
+- **Search & filter** — find mods by name, author, folder, or tags
+
+### PAK File Reading
+- **Native LSPK v18 reader** — reads Larian's proprietary `.pak` archive format directly, with no external tools
+- **Extracts `meta.lsx`** — parses mod metadata from inside `.pak` files when `info.json` isn't available
+- **LZ4 & Zlib decompression** — handles both Solid and non-Solid compressed archives using macOS's built-in Compression framework
+
+### modsettings.lsx Management
+- **Reads & writes** the game's `modsettings.lsx` configuration file
+- **Preserves GustavDev** — always keeps the required base game module entry
+- **Auto-backup** — creates a timestamped backup before every save
+- **File locking** — optionally locks `modsettings.lsx` (via `chflags uchg`) to prevent the game from overwriting your configuration
+
+### Profiles
+- **Save** your current mod configuration (load order + active mods) as a named profile
+- **Load** profiles to quickly switch between setups
+- **Import / export** profiles as JSON for sharing with others
+
+### Script Extender Integration
+- **Status detection** — checks if `bg3se-macos` is installed and deployed
+- **SE mod flagging** — identifies mods that require the Script Extender (by detecting `ScriptExtender/Config.json` inside `.pak` files)
+- **Installation guide** — provides step-by-step instructions for installing bg3se-macos
+- **Log viewer** — read SE logs directly from the app
+- **Debug options** — documents `BG3SE_NO_HOOKS`, `BG3SE_NO_NET`, `BG3SE_MINIMAL` environment variables
+
+### Game Launch
+- **Launch BG3** directly from the app via Steam
+- **Quick access** — open Mods folder, modsettings.lsx, or SE logs in Finder
+
+## Requirements
+
+- **macOS 13 (Ventura)** or later
+- **Baldur's Gate 3** installed via Steam
+- **Xcode 15+** or Swift 5.9+ toolchain (for building)
+- [bg3se-macos](https://github.com/tdimino/bg3se-macos) (optional, for Script Extender mods)
+
+## Building
+
+```bash
+# Clone the repository
+git clone https://github.com/ShaiLaric/BG3MacModManager.git
+cd BG3MacModManager
+
+# Build with Swift Package Manager
+swift build
+
+# Run
+swift run BG3MacModManager
+
+# Or open in Xcode
+open Package.swift
+```
+
+For release builds:
+```bash
+swift build -c release
+```
+
+## File Locations
+
+The app works with these standard BG3 paths on macOS:
+
+| Item | Path |
+|------|------|
+| Mods folder | `~/Documents/Larian Studios/Baldur's Gate 3/Mods/` |
+| Mod settings | `~/Documents/Larian Studios/Baldur's Gate 3/PlayerProfiles/Public/modsettings.lsx` |
+| Save games | `~/Documents/Larian Studios/Baldur's Gate 3/PlayerProfiles/Public/Savegames/Story/` |
+| Game (Steam) | `~/Library/Application Support/Steam/steamapps/common/Baldurs Gate 3/` |
+| SE dylib | `...Baldur's Gate 3.app/Contents/MacOS/libbg3se.dylib` |
+| SE logs | `~/Library/Application Support/BG3SE/logs/` |
+| App profiles | `~/Library/Application Support/BG3MacModManager/Profiles/` |
+| App backups | `~/Library/Application Support/BG3MacModManager/Backups/` |
+
+## Project Structure
+
+```
+Sources/BG3MacModManager/
+├── App/
+│   ├── BG3MacModManagerApp.swift   # SwiftUI app entry point
+│   └── AppState.swift              # Central observable state
+├── Models/
+│   ├── ModInfo.swift               # Mod data model
+│   └── ModProfile.swift            # Profile data model
+├── Services/
+│   ├── PakReader.swift             # LSPK v18 .pak file reader
+│   ├── ModSettingsService.swift    # modsettings.lsx read/write
+│   ├── ModDiscoveryService.swift   # Mod folder scanning
+│   ├── ScriptExtenderService.swift # bg3se-macos integration
+│   ├── ProfileService.swift        # Profile save/load
+│   ├── BackupService.swift         # Backup management
+│   └── GameLaunchService.swift     # Game launch via Steam
+├── Views/
+│   ├── ContentView.swift           # Main window with sidebar
+│   ├── ModListView.swift           # Active/inactive mod lists
+│   ├── ModRowView.swift            # Single mod row
+│   ├── ModDetailView.swift         # Mod detail panel
+│   ├── ProfileManagerView.swift    # Profile management
+│   ├── BackupManagerView.swift     # Backup management
+│   ├── SEStatusView.swift          # Script Extender status
+│   └── SettingsView.swift          # App preferences
+└── Utilities/
+    ├── FileLocations.swift         # macOS file path registry
+    └── Version64.swift             # BG3 version encoding/decoding
+```
+
+## How It Works
+
+### Mod Discovery
+1. Scans `~/Documents/Larian Studios/Baldur's Gate 3/Mods/` for `.pak` files
+2. For each `.pak`, attempts to read metadata in this order:
+   - `info.json` alongside the `.pak` file (most common for NexusMods downloads)
+   - `meta.lsx` extracted from inside the `.pak` file (requires LSPK v18 parsing)
+   - Falls back to deriving the mod name from the filename
+3. Cross-references with `modsettings.lsx` to determine active/inactive state
+
+### Load Order
+- The `ModOrder` section of `modsettings.lsx` defines which mods load and in what order
+- **Last loaded wins** for conflicting changes — mods later in the list override earlier ones
+- `GustavDev` (the base game module) is always preserved as the first entry
+
+### macOS-Specific Notes
+- Only `.pak`-based mods work on macOS (no DLL/native mods)
+- The Mods directory must be flat — no subdirectories (the game resets `modsettings.lsx` otherwise)
+- File locking via `chflags uchg` prevents the game from overwriting your settings
+
+## Contributing
+
+Contributions are welcome! Please feel free to open issues or submit pull requests.
+
+## License
+
+This project is open source. See the LICENSE file for details.
+
+## Acknowledgments
+
+- [LaughingLeader/BG3ModManager](https://github.com/LaughingLeader/BG3ModManager) — the original Windows BG3 Mod Manager
+- [tdimino/bg3se-macos](https://github.com/tdimino/bg3se-macos) — Script Extender for macOS
+- [Norbyte/lslib](https://github.com/Norbyte/lslib) — reference for LSPK format and LSX parsing
+- [BG3 Modding Wiki](https://bg3.wiki/wiki/Modding:Installing_mods) — modding documentation

--- a/Sources/BG3MacModManager/App/AppState.swift
+++ b/Sources/BG3MacModManager/App/AppState.swift
@@ -1,0 +1,338 @@
+import SwiftUI
+import Combine
+
+/// Central observable state for the entire application.
+@MainActor
+final class AppState: ObservableObject {
+
+    // MARK: - Published State
+
+    /// Mods currently in the active load order.
+    @Published var activeMods: [ModInfo] = []
+
+    /// Mods discovered but not in the active load order.
+    @Published var inactiveMods: [ModInfo] = []
+
+    /// Currently selected mod (for detail panel).
+    @Published var selectedModID: String?
+
+    /// Saved profiles.
+    @Published var profiles: [ModProfile] = []
+
+    /// Script Extender status.
+    @Published var seStatus: ScriptExtenderService.SEStatus?
+
+    /// Backup list.
+    @Published var backups: [BackupService.Backup] = []
+
+    /// Whether the game is detected as installed.
+    @Published var isGameInstalled: Bool = false
+
+    /// Status / error messages.
+    @Published var statusMessage: String = ""
+    @Published var errorMessage: String?
+    @Published var showError: Bool = false
+
+    /// Loading state.
+    @Published var isLoading: Bool = false
+
+    // MARK: - Services
+
+    let modSettingsService = ModSettingsService()
+    let discoveryService = ModDiscoveryService()
+    let profileService = ProfileService()
+    let backupService = BackupService()
+    let seService = ScriptExtenderService()
+    let launchService = GameLaunchService()
+
+    // MARK: - Initialization
+
+    init() {
+        isGameInstalled = FileLocations.isGameInstalled
+    }
+
+    func initialLoad() {
+        Task {
+            await refreshAll()
+        }
+    }
+
+    // MARK: - Refresh
+
+    func refreshAll() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        await refreshMods()
+        await refreshProfiles()
+        await refreshBackups()
+        refreshSEStatus()
+    }
+
+    func refreshMods() async {
+        do {
+            let result = try discoveryService.discoverModsWithState()
+            activeMods = result.active
+            inactiveMods = result.inactive
+            statusMessage = "Found \(activeMods.count) active, \(inactiveMods.count) inactive mods"
+        } catch {
+            showError(error)
+        }
+    }
+
+    func refreshProfiles() async {
+        do {
+            profiles = try profileService.listProfiles()
+        } catch {
+            showError(error)
+        }
+    }
+
+    func refreshBackups() async {
+        do {
+            backups = try backupService.listBackups()
+        } catch {
+            showError(error)
+        }
+    }
+
+    func refreshSEStatus() {
+        seStatus = seService.checkStatus()
+    }
+
+    // MARK: - Mod Management
+
+    /// Activate a mod (move from inactive to active).
+    func activateMod(_ mod: ModInfo) {
+        guard let index = inactiveMods.firstIndex(where: { $0.uuid == mod.uuid }) else { return }
+        inactiveMods.remove(at: index)
+        activeMods.append(mod)
+    }
+
+    /// Deactivate a mod (move from active to inactive).
+    func deactivateMod(_ mod: ModInfo) {
+        guard !mod.isBasicGameModule else { return } // Can't deactivate GustavDev
+        guard let index = activeMods.firstIndex(where: { $0.uuid == mod.uuid }) else { return }
+        activeMods.remove(at: index)
+        inactiveMods.append(mod)
+        inactiveMods.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// Activate all inactive mods.
+    func activateAll() {
+        activeMods.append(contentsOf: inactiveMods)
+        inactiveMods.removeAll()
+    }
+
+    /// Deactivate all active mods (except GustavDev).
+    func deactivateAll() {
+        let toDeactivate = activeMods.filter { !$0.isBasicGameModule }
+        inactiveMods.append(contentsOf: toDeactivate)
+        inactiveMods.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        activeMods.removeAll(where: { !$0.isBasicGameModule })
+    }
+
+    /// Move a mod in the active load order.
+    func moveActiveMod(from source: IndexSet, to destination: Int) {
+        activeMods.move(fromOffsets: source, toOffset: destination)
+    }
+
+    // MARK: - Save to modsettings.lsx
+
+    /// Write the current active mod configuration to modsettings.lsx.
+    func saveModSettings() async {
+        do {
+            // Create backup first
+            try backupService.backupModSettings()
+
+            // Unlock if locked
+            backupService.unlockModSettings()
+
+            // Write new settings
+            try modSettingsService.write(activeMods: activeMods)
+
+            // Optionally lock to prevent game from overwriting
+            backupService.lockModSettings()
+
+            statusMessage = "Saved \(activeMods.count) mods to modsettings.lsx"
+            await refreshBackups()
+        } catch {
+            showError(error)
+        }
+    }
+
+    // MARK: - Profiles
+
+    func saveProfile(name: String) async {
+        do {
+            let profile = try profileService.save(name: name, activeMods: activeMods)
+            profiles.insert(profile, at: 0)
+            statusMessage = "Profile '\(name)' saved"
+        } catch {
+            showError(error)
+        }
+    }
+
+    func loadProfile(_ profile: ModProfile) async {
+        // Reconstruct active/inactive lists from the profile
+        let allMods = activeMods + inactiveMods
+        var newActive: [ModInfo] = []
+        var remainingUUIDs = Set(allMods.map(\.uuid))
+
+        for uuid in profile.activeModUUIDs {
+            if let mod = allMods.first(where: { $0.uuid == uuid }) {
+                newActive.append(mod)
+                remainingUUIDs.remove(uuid)
+            } else if let entry = profile.mods.first(where: { $0.uuid == uuid }) {
+                // Create a placeholder mod from the profile entry
+                let mod = ModInfo(
+                    uuid: entry.uuid,
+                    folder: entry.folder,
+                    name: entry.name,
+                    author: "Unknown",
+                    modDescription: "",
+                    version64: entry.version64,
+                    md5: entry.md5,
+                    tags: [],
+                    dependencies: [],
+                    requiresScriptExtender: false,
+                    pakFileName: nil,
+                    pakFilePath: nil,
+                    metadataSource: .modSettings
+                )
+                newActive.append(mod)
+            }
+        }
+
+        let newInactive = allMods.filter { remainingUUIDs.contains($0.uuid) }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+        activeMods = newActive
+        inactiveMods = newInactive
+        statusMessage = "Loaded profile '\(profile.name)'"
+    }
+
+    func deleteProfile(_ profile: ModProfile) async {
+        do {
+            try profileService.delete(profile: profile)
+            profiles.removeAll { $0.id == profile.id }
+            statusMessage = "Deleted profile '\(profile.name)'"
+        } catch {
+            showError(error)
+        }
+    }
+
+    // MARK: - Backups
+
+    func restoreBackup(_ backup: BackupService.Backup) async {
+        do {
+            try backupService.restore(backup: backup)
+            await refreshMods()
+            statusMessage = "Restored from backup"
+        } catch {
+            showError(error)
+        }
+    }
+
+    func deleteBackup(_ backup: BackupService.Backup) async {
+        do {
+            try backupService.delete(backup: backup)
+            await refreshBackups()
+        } catch {
+            showError(error)
+        }
+    }
+
+    // MARK: - Game Launch
+
+    func launchGame() {
+        do {
+            try launchService.launchGame()
+            statusMessage = "Launching Baldur's Gate 3..."
+        } catch {
+            showError(error)
+        }
+    }
+
+    // MARK: - Import Mod
+
+    /// Import a mod from a file URL (ZIP or .pak).
+    func importMod(from url: URL) async {
+        do {
+            let modsFolder = FileLocations.modsFolder
+            try FileLocations.ensureDirectoryExists(modsFolder)
+
+            if url.pathExtension.lowercased() == "zip" {
+                try await importZip(url)
+            } else if url.pathExtension.lowercased() == "pak" {
+                let destination = modsFolder.appendingPathComponent(url.lastPathComponent)
+                if FileManager.default.fileExists(atPath: destination.path) {
+                    try FileManager.default.removeItem(at: destination)
+                }
+                try FileManager.default.copyItem(at: url, to: destination)
+            }
+
+            await refreshMods()
+            statusMessage = "Imported \(url.lastPathComponent)"
+        } catch {
+            showError(error)
+        }
+    }
+
+    private func importZip(_ zipURL: URL) async throws {
+        let modsFolder = FileLocations.modsFolder
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Use ditto to extract ZIP on macOS (handles most ZIP formats)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        process.arguments = ["-xk", zipURL.path, tempDir.path]
+        try process.run()
+        process.waitUntilExit()
+
+        // Find all .pak files in the extracted content
+        let enumerator = FileManager.default.enumerator(at: tempDir, includingPropertiesForKeys: nil)
+        while let fileURL = enumerator?.nextObject() as? URL {
+            if fileURL.pathExtension.lowercased() == "pak" {
+                let destination = modsFolder.appendingPathComponent(fileURL.lastPathComponent)
+                if FileManager.default.fileExists(atPath: destination.path) {
+                    try FileManager.default.removeItem(at: destination)
+                }
+                try FileManager.default.copyItem(at: fileURL, to: destination)
+            }
+            // Also copy info.json if found
+            if fileURL.lastPathComponent.lowercased() == "info.json" {
+                let destination = modsFolder.appendingPathComponent("info.json")
+                if FileManager.default.fileExists(atPath: destination.path) {
+                    try FileManager.default.removeItem(at: destination)
+                }
+                try FileManager.default.copyItem(at: fileURL, to: destination)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    var selectedMod: ModInfo? {
+        guard let id = selectedModID else { return nil }
+        return activeMods.first(where: { $0.uuid == id })
+            ?? inactiveMods.first(where: { $0.uuid == id })
+    }
+
+    /// Missing dependency check for active mods.
+    func missingDependencies(for mod: ModInfo) -> [ModDependency] {
+        let activeUUIDs = Set(activeMods.map(\.uuid))
+        return mod.dependencies.filter { dep in
+            !activeUUIDs.contains(dep.uuid) &&
+            dep.uuid != Constants.gustavDevUUID
+        }
+    }
+
+    private func showError(_ error: Error) {
+        errorMessage = error.localizedDescription
+        showError = true
+        statusMessage = "Error: \(error.localizedDescription)"
+    }
+}

--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+@main
+struct BG3MacModManagerApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(appState)
+                .onAppear {
+                    appState.initialLoad()
+                }
+                .frame(minWidth: 900, minHeight: 600)
+        }
+        .windowStyle(.titleBar)
+        .defaultSize(width: 1100, height: 750)
+        .commands {
+            CommandGroup(after: .newItem) {
+                Button("Import Mod...") {
+                    importModFromPanel()
+                }
+                .keyboardShortcut("i", modifiers: .command)
+
+                Divider()
+
+                Button("Refresh Mods") {
+                    Task { await appState.refreshMods() }
+                }
+                .keyboardShortcut("r", modifiers: .command)
+            }
+
+            CommandGroup(replacing: .help) {
+                Button("Open Mods Folder") {
+                    appState.launchService.openModsFolder()
+                }
+                Button("Open modsettings.lsx") {
+                    appState.launchService.openModSettings()
+                }
+            }
+        }
+
+        #if os(macOS)
+        Settings {
+            SettingsView()
+                .environmentObject(appState)
+        }
+        #endif
+    }
+
+    private func importModFromPanel() {
+        let panel = NSOpenPanel()
+        panel.title = "Import Mod"
+        panel.allowedContentTypes = [
+            .init(filenameExtension: "pak")!,
+            .init(filenameExtension: "zip")!
+        ]
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+
+        if panel.runModal() == .OK {
+            for url in panel.urls {
+                Task {
+                    await appState.importMod(from: url)
+                }
+            }
+        }
+    }
+}

--- a/Sources/BG3MacModManager/Models/ModInfo.swift
+++ b/Sources/BG3MacModManager/Models/ModInfo.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Represents a single BG3 mod with all known metadata.
+struct ModInfo: Identifiable, Codable, Equatable {
+    /// Unique identifier for this mod (from meta.lsx / info.json UUID field).
+    let uuid: String
+
+    /// The folder name inside the `.pak` archive (e.g., "MyModFolder").
+    var folder: String
+
+    /// Display name of the mod.
+    var name: String
+
+    /// Author of the mod.
+    var author: String
+
+    /// Description text.
+    var modDescription: String
+
+    /// Version in BG3's Int64 format.
+    var version64: Int64
+
+    /// MD5 hash (often empty in practice).
+    var md5: String
+
+    /// Tags (semicolon-separated in meta.lsx).
+    var tags: [String]
+
+    /// Dependencies (UUIDs of required mods).
+    var dependencies: [ModDependency]
+
+    /// Whether this mod requires bg3se-macos (Script Extender).
+    var requiresScriptExtender: Bool
+
+    /// The `.pak` filename on disk (e.g., "MyMod.pak").
+    var pakFileName: String?
+
+    /// Full path to the `.pak` file.
+    var pakFilePath: URL?
+
+    /// Source of the metadata (how it was discovered).
+    var metadataSource: MetadataSource
+
+    // MARK: - Identifiable
+
+    var id: String { uuid }
+
+    // MARK: - Computed Properties
+
+    var version: Version64 {
+        Version64(rawValue: version64)
+    }
+
+    var isBasicGameModule: Bool {
+        uuid == Constants.gustavDevUUID
+    }
+
+    // MARK: - Factory Methods
+
+    /// Creates a ModInfo for the required GustavDev base game module.
+    static var gustavDev: ModInfo {
+        ModInfo(
+            uuid: Constants.gustavDevUUID,
+            folder: "GustavDev",
+            name: "GustavDev",
+            author: "Larian Studios",
+            modDescription: "Base game module (required)",
+            version64: Constants.gustavDevVersion64,
+            md5: "",
+            tags: [],
+            dependencies: [],
+            requiresScriptExtender: false,
+            pakFileName: nil,
+            pakFilePath: nil,
+            metadataSource: .builtIn
+        )
+    }
+
+    /// Creates a minimal ModInfo from just a pak filename when no metadata is available.
+    static func fromPakFilename(_ filename: String, at url: URL) -> ModInfo {
+        let name = filename.replacingOccurrences(of: ".pak", with: "")
+        return ModInfo(
+            uuid: UUID().uuidString.lowercased(),
+            folder: name,
+            name: name,
+            author: "Unknown",
+            modDescription: "",
+            version64: Version64(major: 1).rawValue,
+            md5: "",
+            tags: [],
+            dependencies: [],
+            requiresScriptExtender: false,
+            pakFileName: filename,
+            pakFilePath: url,
+            metadataSource: .filename
+        )
+    }
+}
+
+// MARK: - Supporting Types
+
+struct ModDependency: Codable, Equatable, Identifiable {
+    let uuid: String
+    var folder: String
+    var name: String
+    var version64: Int64
+    var md5: String
+
+    var id: String { uuid }
+}
+
+/// Indicates how mod metadata was obtained.
+enum MetadataSource: String, Codable {
+    case infoJson     // Parsed from info.json alongside the .pak
+    case metaLsx      // Extracted from meta.lsx inside the .pak
+    case filename     // Fallback: derived from the .pak filename
+    case builtIn      // Hard-coded (e.g., GustavDev)
+    case modSettings  // Imported from modsettings.lsx
+}
+
+// MARK: - Constants
+
+enum Constants {
+    static let gustavDevUUID = "28ac9ce2-2aba-8cda-b3b5-6e922f71b6b8"
+    static let gustavDevVersion64: Int64 = 145_100_779_997_082_624 // 36028797018963968 in some versions
+
+    /// Steam App ID for BG3.
+    static let steamAppID = "1086940"
+}

--- a/Sources/BG3MacModManager/Models/ModProfile.swift
+++ b/Sources/BG3MacModManager/Models/ModProfile.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// A saved mod configuration (load order + active mods).
+struct ModProfile: Identifiable, Codable {
+    let id: UUID
+    var name: String
+    var createdAt: Date
+    var updatedAt: Date
+
+    /// Ordered list of active mod UUIDs (defines load order).
+    var activeModUUIDs: [String]
+
+    /// Full metadata for each mod in the profile (for portability).
+    var mods: [ModProfileEntry]
+
+    init(name: String, activeModUUIDs: [String], mods: [ModProfileEntry]) {
+        self.id = UUID()
+        self.name = name
+        self.createdAt = Date()
+        self.updatedAt = Date()
+        self.activeModUUIDs = activeModUUIDs
+        self.mods = mods
+    }
+}
+
+/// Minimal mod metadata stored in a profile for reconstruction.
+struct ModProfileEntry: Codable, Identifiable {
+    let uuid: String
+    var folder: String
+    var name: String
+    var version64: Int64
+    var md5: String
+
+    var id: String { uuid }
+
+    init(from mod: ModInfo) {
+        self.uuid = mod.uuid
+        self.folder = mod.folder
+        self.name = mod.name
+        self.version64 = mod.version64
+        self.md5 = mod.md5
+    }
+}

--- a/Sources/BG3MacModManager/Services/BackupService.swift
+++ b/Sources/BG3MacModManager/Services/BackupService.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// Manages backups of modsettings.lsx before making changes.
+final class BackupService {
+
+    struct Backup: Identifiable {
+        let id: String
+        let url: URL
+        let date: Date
+        let fileSize: Int
+
+        var displayName: String {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .short
+            return "Backup - \(formatter.string(from: date))"
+        }
+    }
+
+    // MARK: - Create Backup
+
+    /// Create a timestamped backup of modsettings.lsx before any modifications.
+    @discardableResult
+    func backupModSettings() throws -> Backup {
+        let source = FileLocations.modSettingsFile
+        guard FileManager.default.fileExists(atPath: source.path) else {
+            throw BackupError.sourceNotFound
+        }
+
+        try FileLocations.ensureDirectoryExists(FileLocations.backupsDirectory)
+
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let filename = "modsettings-\(timestamp).lsx"
+        let destination = FileLocations.backupsDirectory.appendingPathComponent(filename)
+
+        try FileManager.default.copyItem(at: source, to: destination)
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: destination.path)
+        let size = (attrs[.size] as? Int) ?? 0
+
+        return Backup(id: filename, url: destination, date: Date(), fileSize: size)
+    }
+
+    // MARK: - List Backups
+
+    /// List all available backups, newest first.
+    func listBackups() throws -> [Backup] {
+        let dir = FileLocations.backupsDirectory
+        guard FileManager.default.fileExists(atPath: dir.path) else { return [] }
+
+        let files = try FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey])
+        let lsxFiles = files.filter { $0.pathExtension == "lsx" }
+
+        return lsxFiles.compactMap { url -> Backup? in
+            guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                  let date = attrs[.modificationDate] as? Date,
+                  let size = attrs[.size] as? Int else {
+                return nil
+            }
+            return Backup(id: url.lastPathComponent, url: url, date: date, fileSize: size)
+        }.sorted { $0.date > $1.date }
+    }
+
+    // MARK: - Restore
+
+    /// Restore modsettings.lsx from a backup.
+    func restore(backup: Backup) throws {
+        let destination = FileLocations.modSettingsFile
+
+        // Unlock the file if it's locked (macOS file locking)
+        unlockFile(at: destination)
+
+        // Create a safety backup before restoring
+        if FileManager.default.fileExists(atPath: destination.path) {
+            let safetyBackup = FileLocations.backupsDirectory.appendingPathComponent("pre-restore-\(Date().timeIntervalSince1970).lsx")
+            try? FileManager.default.copyItem(at: destination, to: safetyBackup)
+            try FileManager.default.removeItem(at: destination)
+        }
+
+        try FileManager.default.copyItem(at: backup.url, to: destination)
+    }
+
+    // MARK: - Delete
+
+    /// Delete a specific backup.
+    func delete(backup: Backup) throws {
+        try FileManager.default.removeItem(at: backup.url)
+    }
+
+    /// Delete all backups older than the given number of days.
+    func pruneBackups(olderThanDays days: Int = 30) throws {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: Date())!
+        let backups = try listBackups()
+
+        for backup in backups where backup.date < cutoff {
+            try? FileManager.default.removeItem(at: backup.url)
+        }
+    }
+
+    // MARK: - File Locking
+
+    /// Lock modsettings.lsx to prevent the game from overwriting it.
+    func lockModSettings() {
+        lockFile(at: FileLocations.modSettingsFile)
+    }
+
+    /// Unlock modsettings.lsx so it can be modified.
+    func unlockModSettings() {
+        unlockFile(at: FileLocations.modSettingsFile)
+    }
+
+    private func lockFile(at url: URL) {
+        // Uses chflags(2) to set the user immutable flag (uchg).
+        let path = url.path
+        guard FileManager.default.fileExists(atPath: path) else { return }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/chflags")
+        process.arguments = ["uchg", path]
+        try? process.run()
+        process.waitUntilExit()
+    }
+
+    private func unlockFile(at url: URL) {
+        let path = url.path
+        guard FileManager.default.fileExists(atPath: path) else { return }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/chflags")
+        process.arguments = ["nouchg", path]
+        try? process.run()
+        process.waitUntilExit()
+    }
+
+    // MARK: - Errors
+
+    enum BackupError: Error, LocalizedError {
+        case sourceNotFound
+
+        var errorDescription: String? {
+            switch self {
+            case .sourceNotFound: return "modsettings.lsx not found - nothing to back up"
+            }
+        }
+    }
+}

--- a/Sources/BG3MacModManager/Services/GameLaunchService.swift
+++ b/Sources/BG3MacModManager/Services/GameLaunchService.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Launches Baldur's Gate 3 via Steam with optional Script Extender support.
+final class GameLaunchService {
+
+    private let seService = ScriptExtenderService()
+
+    struct LaunchOptions {
+        var useScriptExtender: Bool = true
+        var seNoHooks: Bool = false
+        var seNoNet: Bool = false
+        var seMinimal: Bool = false
+    }
+
+    /// Launch BG3 through Steam.
+    ///
+    /// On macOS, we use `open steam://run/<appId>` which tells Steam to launch the game.
+    /// If Script Extender is needed, the user must have Steam launch options configured
+    /// to point to the bg3w.sh wrapper script.
+    func launchGame(options: LaunchOptions = LaunchOptions()) throws {
+        // Use Steam's URL protocol to launch the game
+        let steamURL = URL(string: "steam://run/\(Constants.steamAppID)")!
+
+        let workspace = NSWorkspace.shared
+        workspace.open(steamURL)
+    }
+
+    /// Check if Steam is running.
+    func isSteamRunning() -> Bool {
+        let workspace = NSWorkspace.shared
+        return workspace.runningApplications.contains { app in
+            app.bundleIdentifier == "com.valvesoftware.steam"
+        }
+    }
+
+    /// Check if BG3 is currently running.
+    func isGameRunning() -> Bool {
+        let workspace = NSWorkspace.shared
+        return workspace.runningApplications.contains { app in
+            app.localizedName?.contains("Baldur's Gate 3") == true ||
+            app.bundleIdentifier?.contains("baldursgate3") == true ||
+            app.bundleIdentifier?.contains("larianstudios") == true
+        }
+    }
+
+    /// Open the game's Mods folder in Finder.
+    func openModsFolder() {
+        let url = FileLocations.modsFolder
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// Open modsettings.lsx in the default text editor.
+    func openModSettings() {
+        let url = FileLocations.modSettingsFile
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// Open SE logs folder in Finder.
+    func openSELogs() {
+        let url = FileLocations.seLogsDirectory
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
+
+// Needed for NSWorkspace on macOS
+import AppKit

--- a/Sources/BG3MacModManager/Services/ModDiscoveryService.swift
+++ b/Sources/BG3MacModManager/Services/ModDiscoveryService.swift
@@ -1,0 +1,269 @@
+import Foundation
+
+/// Discovers mods by scanning the Mods folder and parsing metadata from
+/// `info.json` files, `meta.lsx` inside `.pak` archives, or filenames.
+final class ModDiscoveryService {
+
+    private let modSettingsService = ModSettingsService()
+
+    /// Discover all mods in the Mods directory.
+    func discoverMods() throws -> [ModInfo] {
+        let modsFolder = FileLocations.modsFolder
+
+        guard FileManager.default.fileExists(atPath: modsFolder.path) else {
+            return []
+        }
+
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: modsFolder,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        )
+
+        // Find all .pak files
+        let pakFiles = contents.filter { $0.pathExtension.lowercased() == "pak" }
+
+        var discoveredMods: [ModInfo] = []
+
+        for pakURL in pakFiles {
+            if let mod = discoverMod(pakURL: pakURL, allFiles: contents) {
+                discoveredMods.append(mod)
+            }
+        }
+
+        return discoveredMods
+    }
+
+    /// Discover mods and merge with current modsettings.lsx to determine active state.
+    func discoverModsWithState() throws -> (active: [ModInfo], inactive: [ModInfo]) {
+        let allMods = try discoverMods()
+
+        // Read current modsettings.lsx
+        let currentSettings: ModSettingsService.ModSettings?
+        do {
+            currentSettings = try modSettingsService.read()
+        } catch {
+            currentSettings = nil
+        }
+
+        guard let settings = currentSettings else {
+            // No modsettings.lsx: all mods are inactive
+            return (active: [], inactive: allMods)
+        }
+
+        var active: [ModInfo] = []
+        var inactiveSet = Set(allMods.map { $0.uuid })
+
+        // Build active list in the order defined by ModOrder
+        for uuid in settings.modOrder {
+            if uuid == Constants.gustavDevUUID { continue }
+
+            if let mod = allMods.first(where: { $0.uuid == uuid }) {
+                active.append(mod)
+                inactiveSet.remove(uuid)
+            } else if let desc = settings.mods[uuid] {
+                // Mod is in modsettings but .pak not found - create entry from settings
+                let mod = ModInfo(
+                    uuid: desc.uuid,
+                    folder: desc.name,
+                    name: desc.name,
+                    author: "Unknown",
+                    modDescription: "",
+                    version64: Int64(desc.version64) ?? 36028797018963968,
+                    md5: desc.md5,
+                    tags: [],
+                    dependencies: [],
+                    requiresScriptExtender: false,
+                    pakFileName: nil,
+                    pakFilePath: nil,
+                    metadataSource: .modSettings
+                )
+                active.append(mod)
+            }
+        }
+
+        let inactive = allMods.filter { inactiveSet.contains($0.uuid) }
+
+        return (active: active, inactive: inactive)
+    }
+
+    // MARK: - Single Mod Discovery
+
+    private func discoverMod(pakURL: URL, allFiles: [URL]) -> ModInfo? {
+        let pakFilename = pakURL.lastPathComponent
+        let baseName = pakURL.deletingPathExtension().lastPathComponent
+
+        // Strategy 1: Look for info.json alongside the .pak
+        let infoJsonURL = pakURL.deletingLastPathComponent().appendingPathComponent("info.json")
+        if let mod = parseInfoJson(at: infoJsonURL, pakFilename: pakFilename, pakURL: pakURL) {
+            return mod
+        }
+
+        // Also check for <modname>.json
+        let namedJsonURL = pakURL.deletingLastPathComponent().appendingPathComponent("\(baseName).json")
+        if let mod = parseInfoJson(at: namedJsonURL, pakFilename: pakFilename, pakURL: pakURL) {
+            return mod
+        }
+
+        // Strategy 2: Extract meta.lsx from inside the .pak
+        if let mod = parseMetaLsx(from: pakURL, pakFilename: pakFilename) {
+            return mod
+        }
+
+        // Strategy 3: Fall back to filename-based detection
+        return ModInfo.fromPakFilename(pakFilename, at: pakURL)
+    }
+
+    // MARK: - info.json Parsing
+
+    private func parseInfoJson(at url: URL, pakFilename: String, pakURL: URL) -> ModInfo? {
+        guard FileManager.default.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+
+        struct InfoJsonRoot: Decodable {
+            let mods: [InfoJsonMod]?
+            // Some info.json formats use "Mods" instead of "mods"
+            enum CodingKeys: String, CodingKey {
+                case mods
+                case Mods
+            }
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                if let mods = try? container.decode([InfoJsonMod].self, forKey: .mods) {
+                    self.mods = mods
+                } else {
+                    self.mods = try? container.decode([InfoJsonMod].self, forKey: .Mods)
+                }
+            }
+        }
+
+        struct InfoJsonMod: Decodable {
+            let modName: String?
+            let folderName: String?
+            let UUID: String?
+            let version: String?
+            let MD5: String?
+            let Name: String?
+            let Folder: String?
+            let Author: String?
+            let Description: String?
+
+            // Flexible decoding for different naming conventions
+            enum CodingKeys: String, CodingKey {
+                case modName, folderName, UUID, version, MD5
+                case Name, Folder, Author, Description
+            }
+        }
+
+        guard let root = try? JSONDecoder().decode(InfoJsonRoot.self, from: data),
+              let modEntry = root.mods?.first else {
+            return nil
+        }
+
+        let uuid = modEntry.UUID ?? UUID().uuidString.lowercased()
+        let name = modEntry.modName ?? modEntry.Name ?? pakFilename.replacingOccurrences(of: ".pak", with: "")
+        let folder = modEntry.folderName ?? modEntry.Folder ?? name
+
+        let version64: Int64
+        if let versionStr = modEntry.version, let v = Version64(versionString: versionStr) {
+            version64 = v.rawValue
+        } else {
+            version64 = Version64(major: 1).rawValue
+        }
+
+        let requiresSE = PakReader.containsScriptExtender(at: pakURL)
+
+        return ModInfo(
+            uuid: uuid,
+            folder: folder,
+            name: name,
+            author: modEntry.Author ?? "Unknown",
+            modDescription: modEntry.Description ?? "",
+            version64: version64,
+            md5: modEntry.MD5 ?? "",
+            tags: [],
+            dependencies: [],
+            requiresScriptExtender: requiresSE,
+            pakFileName: pakFilename,
+            pakFilePath: pakURL,
+            metadataSource: .infoJson
+        )
+    }
+
+    // MARK: - meta.lsx Parsing (from inside .pak)
+
+    private func parseMetaLsx(from pakURL: URL, pakFilename: String) -> ModInfo? {
+        guard let metaData = try? PakReader.extractMetaLsx(from: pakURL),
+              let document = try? XMLDocument(data: metaData) else {
+            return nil
+        }
+
+        // Parse ModuleInfo
+        guard let moduleInfoNodes = try? document.nodes(forXPath: "//node[@id='ModuleInfo']"),
+              let moduleInfo = moduleInfoNodes.first as? XMLElement else {
+            return nil
+        }
+
+        let uuid = moduleInfo.lsxAttribute("UUID") ?? UUID().uuidString.lowercased()
+        let folder = moduleInfo.lsxAttribute("Folder") ?? pakFilename.replacingOccurrences(of: ".pak", with: "")
+        let name = moduleInfo.lsxAttribute("Name") ?? folder
+        let author = moduleInfo.lsxAttribute("Author") ?? "Unknown"
+        let description = moduleInfo.lsxAttribute("Description") ?? ""
+        let version64Str = moduleInfo.lsxAttribute("Version64") ?? "36028797018963968"
+        let md5 = moduleInfo.lsxAttribute("MD5") ?? ""
+        let tagsStr = moduleInfo.lsxAttribute("Tags") ?? ""
+        let tags = tagsStr.split(separator: ";").map(String.init)
+
+        // Parse Dependencies
+        var dependencies: [ModDependency] = []
+        if let depNodes = try? document.nodes(forXPath: "//node[@id='Dependencies']/children/node[@id='ModuleShortDesc']") {
+            for node in depNodes {
+                guard let elem = node as? XMLElement,
+                      let depUUID = elem.lsxAttribute("UUID") else { continue }
+                dependencies.append(ModDependency(
+                    uuid: depUUID,
+                    folder: elem.lsxAttribute("Folder") ?? "",
+                    name: elem.lsxAttribute("Name") ?? "",
+                    version64: Int64(elem.lsxAttribute("Version64") ?? "0") ?? 0,
+                    md5: elem.lsxAttribute("MD5") ?? ""
+                ))
+            }
+        }
+
+        let requiresSE = PakReader.containsScriptExtender(at: pakURL)
+
+        return ModInfo(
+            uuid: uuid,
+            folder: folder,
+            name: name,
+            author: author,
+            modDescription: description,
+            version64: Int64(version64Str) ?? Version64(major: 1).rawValue,
+            md5: md5,
+            tags: tags,
+            dependencies: dependencies,
+            requiresScriptExtender: requiresSE,
+            pakFileName: pakFilename,
+            pakFilePath: pakURL,
+            metadataSource: .metaLsx
+        )
+    }
+}
+
+// MARK: - XMLElement Extension
+
+private extension XMLElement {
+    /// Extract value from `<attribute id="..." value="..."/>` child element (meta.lsx format).
+    func lsxAttribute(_ id: String) -> String? {
+        guard let children = self.children else { return nil }
+        for child in children {
+            guard let element = child as? XMLElement,
+                  element.name == "attribute",
+                  element.attribute(forName: "id")?.stringValue == id else { continue }
+            return element.attribute(forName: "value")?.stringValue
+        }
+        return nil
+    }
+}

--- a/Sources/BG3MacModManager/Services/ModSettingsService.swift
+++ b/Sources/BG3MacModManager/Services/ModSettingsService.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+/// Reads and writes the `modsettings.lsx` file that controls which mods BG3 loads.
+///
+/// The file has two key sections:
+/// - `ModOrder`: ordered list of mod UUIDs (defines load sequence)
+/// - `Mods`: `ModuleShortDesc` entries with full metadata per mod
+final class ModSettingsService {
+
+    enum ModSettingsError: Error, LocalizedError {
+        case fileNotFound
+        case parseError(String)
+        case writeError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .fileNotFound: return "modsettings.lsx not found"
+            case .parseError(let msg): return "Failed to parse modsettings.lsx: \(msg)"
+            case .writeError(let msg): return "Failed to write modsettings.lsx: \(msg)"
+            }
+        }
+    }
+
+    /// Parsed representation of modsettings.lsx.
+    struct ModSettings {
+        /// Ordered list of active mod UUIDs (defines load order).
+        var modOrder: [String]
+
+        /// Metadata for each active mod, keyed by UUID.
+        var mods: [String: ModuleShortDesc]
+    }
+
+    struct ModuleShortDesc {
+        var folder: String
+        var md5: String
+        var name: String
+        var uuid: String
+        var version64: String
+    }
+
+    // MARK: - Reading
+
+    /// Read and parse modsettings.lsx from the default location.
+    func read() throws -> ModSettings {
+        return try read(from: FileLocations.modSettingsFile)
+    }
+
+    /// Read and parse modsettings.lsx from a specific URL.
+    func read(from url: URL) throws -> ModSettings {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ModSettingsError.fileNotFound
+        }
+
+        let data = try Data(contentsOf: url)
+        let document = try XMLDocument(data: data)
+
+        return try parseDocument(document)
+    }
+
+    private func parseDocument(_ document: XMLDocument) throws -> ModSettings {
+        // Parse ModOrder section
+        let orderNodes = try document.nodes(forXPath: "//node[@id='ModOrder']/children/node[@id='Module']")
+        let modOrder = orderNodes.compactMap { node -> String? in
+            guard let element = node as? XMLElement else { return nil }
+            return element.attributeElement(id: "UUID")
+        }
+
+        // Parse Mods section
+        let modNodes = try document.nodes(forXPath: "//node[@id='Mods']/children/node[@id='ModuleShortDesc']")
+        var mods: [String: ModuleShortDesc] = [:]
+
+        for node in modNodes {
+            guard let element = node as? XMLElement else { continue }
+            guard let uuid = element.attributeElement(id: "UUID") else { continue }
+
+            let desc = ModuleShortDesc(
+                folder:    element.attributeElement(id: "Folder") ?? "",
+                md5:       element.attributeElement(id: "MD5") ?? "",
+                name:      element.attributeElement(id: "Name") ?? "",
+                uuid:      uuid,
+                version64: element.attributeElement(id: "Version64") ?? "36028797018963968"
+            )
+            mods[uuid] = desc
+        }
+
+        return ModSettings(modOrder: modOrder, mods: mods)
+    }
+
+    // MARK: - Writing
+
+    /// Write mod settings to the default modsettings.lsx location.
+    func write(_ settings: ModSettings) throws {
+        try write(settings, to: FileLocations.modSettingsFile)
+    }
+
+    /// Write mod settings to a specific URL.
+    func write(_ settings: ModSettings, to url: URL) throws {
+        let xml = generateXML(settings)
+
+        do {
+            let directory = url.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try xml.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            throw ModSettingsError.writeError(error.localizedDescription)
+        }
+    }
+
+    /// Write mod settings using a list of active ModInfo objects (in load order).
+    func write(activeMods: [ModInfo]) throws {
+        var settings = ModSettings(modOrder: [], mods: [:])
+
+        // Ensure GustavDev is always first
+        let gustavDev = ModInfo.gustavDev
+        settings.modOrder.append(gustavDev.uuid)
+        settings.mods[gustavDev.uuid] = ModuleShortDesc(
+            folder: gustavDev.folder,
+            md5: gustavDev.md5,
+            name: gustavDev.name,
+            uuid: gustavDev.uuid,
+            version64: String(gustavDev.version64)
+        )
+
+        // Add remaining mods in order
+        for mod in activeMods where !mod.isBasicGameModule {
+            settings.modOrder.append(mod.uuid)
+            settings.mods[mod.uuid] = ModuleShortDesc(
+                folder: mod.folder,
+                md5: mod.md5,
+                name: mod.name,
+                uuid: mod.uuid,
+                version64: String(mod.version64)
+            )
+        }
+
+        try write(settings)
+    }
+
+    // MARK: - XML Generation
+
+    private func generateXML(_ settings: ModSettings) -> String {
+        var xml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <save>
+          <version major="4" minor="7" revision="1" build="3"/>
+          <region id="ModuleSettings">
+            <node id="root">
+              <children>
+                <node id="ModOrder">
+                  <children>
+
+        """
+
+        for uuid in settings.modOrder {
+            xml += """
+                            <node id="Module">
+                              <attribute id="UUID" value="\(uuid)" type="FixedString"/>
+                            </node>\n
+            """
+        }
+
+        xml += """
+                  </children>
+                </node>
+                <node id="Mods">
+                  <children>
+
+        """
+
+        // Write mods in the same order as modOrder, then any extras
+        let orderedUUIDs = settings.modOrder + settings.mods.keys.filter { !settings.modOrder.contains($0) }
+
+        for uuid in orderedUUIDs {
+            guard let mod = settings.mods[uuid] else { continue }
+            xml += """
+                            <node id="ModuleShortDesc">
+                              <attribute id="Folder" value="\(escapeXML(mod.folder))" type="LSString"/>
+                              <attribute id="MD5" value="\(escapeXML(mod.md5))" type="LSString"/>
+                              <attribute id="Name" value="\(escapeXML(mod.name))" type="LSString"/>
+                              <attribute id="UUID" value="\(mod.uuid)" type="FixedString"/>
+                              <attribute id="Version64" value="\(mod.version64)" type="int64"/>
+                            </node>\n
+            """
+        }
+
+        xml += """
+                  </children>
+                </node>
+              </children>
+            </node>
+          </region>
+        </save>
+        """
+
+        return xml
+    }
+
+    private func escapeXML(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+}
+
+// MARK: - XMLElement Extension for BG3 Attribute Parsing
+
+private extension XMLElement {
+    /// Extracts the `value` from a child `<attribute id="..." value="..."/>` element.
+    func attributeElement(id: String) -> String? {
+        guard let children = self.children else { return nil }
+        for child in children {
+            guard let element = child as? XMLElement,
+                  element.name == "attribute",
+                  let attrId = element.attribute(forName: "id")?.stringValue,
+                  attrId == id else { continue }
+            return element.attribute(forName: "value")?.stringValue
+        }
+        return nil
+    }
+}

--- a/Sources/BG3MacModManager/Services/PakReader.swift
+++ b/Sources/BG3MacModManager/Services/PakReader.swift
@@ -1,0 +1,340 @@
+import Foundation
+import Compression
+
+/// Reads Larian LSPK v18 `.pak` archive files to extract mod metadata.
+///
+/// The LSPK v18 format structure:
+/// - 4 bytes: "LSPK" magic signature
+/// - Header: version, file list offset/size, flags, priority, MD5, numParts
+/// - File entries: name (256 bytes), offset, compression, sizes
+/// - File data: individually or solid-compressed file contents
+final class PakReader {
+
+    enum PakError: Error, LocalizedError {
+        case invalidSignature
+        case unsupportedVersion(UInt32)
+        case fileListReadFailed
+        case decompressionFailed
+        case fileNotFound(String)
+        case readError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidSignature: return "Not a valid LSPK archive (bad signature)"
+            case .unsupportedVersion(let v): return "Unsupported LSPK version: \(v)"
+            case .fileListReadFailed: return "Failed to read file list from archive"
+            case .decompressionFailed: return "Failed to decompress archive data"
+            case .fileNotFound(let name): return "File not found in archive: \(name)"
+            case .readError(let msg): return "Read error: \(msg)"
+            }
+        }
+    }
+
+    // MARK: - LSPK Structures
+
+    struct PakHeader {
+        let version: UInt32
+        let fileListOffset: UInt64
+        let fileListSize: UInt32
+        let flags: UInt8
+        let priority: UInt8
+        let md5: Data     // 16 bytes
+        let numParts: UInt16
+
+        var isSolid: Bool { flags & 0x04 != 0 }
+    }
+
+    struct FileEntry {
+        let name: String
+        let offset: UInt64
+        let archivePart: UInt8
+        let flags: UInt8
+        let sizeOnDisk: UInt32
+        let uncompressedSize: UInt32
+
+        var compressionMethod: CompressionType {
+            CompressionType(rawValue: flags & 0x0F) ?? .none
+        }
+    }
+
+    enum CompressionType: UInt8 {
+        case none = 0
+        case zlib = 1
+        case lz4  = 2
+    }
+
+    // MARK: - Constants
+
+    private static let signature: [UInt8] = [0x4C, 0x53, 0x50, 0x4B] // "LSPK"
+    private static let headerSize = 4 + 8 + 4 + 1 + 1 + 16 + 2  // 36 bytes after signature
+    private static let fileEntrySize = 256 + 4 + 2 + 1 + 1 + 4 + 4  // 272 bytes
+
+    // MARK: - Public API
+
+    /// List all files in a `.pak` archive.
+    static func listFiles(at url: URL) throws -> [FileEntry] {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { handle.closeFile() }
+        return try readFileEntries(handle: handle)
+    }
+
+    /// Extract a specific file from the `.pak` by name path (e.g., "Mods/MyMod/meta.lsx").
+    static func extractFile(named targetPath: String, from url: URL) throws -> Data {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { handle.closeFile() }
+
+        let (header, entries) = try readHeaderAndEntries(handle: handle)
+
+        guard let entry = entries.first(where: { $0.name == targetPath }) else {
+            throw PakError.fileNotFound(targetPath)
+        }
+
+        return try readFileData(handle: handle, entry: entry, header: header)
+    }
+
+    /// Find and extract `meta.lsx` from a `.pak` file.
+    /// Searches for files matching the pattern `Mods/*/meta.lsx`.
+    static func extractMetaLsx(from url: URL) throws -> Data {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { handle.closeFile() }
+
+        let (header, entries) = try readHeaderAndEntries(handle: handle)
+
+        guard let entry = entries.first(where: { isMetaLsx(path: $0.name) }) else {
+            throw PakError.fileNotFound("Mods/*/meta.lsx")
+        }
+
+        return try readFileData(handle: handle, entry: entry, header: header)
+    }
+
+    /// Check whether a `.pak` contains Script Extender scripts.
+    static func containsScriptExtender(at url: URL) -> Bool {
+        guard let entries = try? listFiles(at: url) else { return false }
+        return entries.contains { $0.name.contains("ScriptExtender/") }
+    }
+
+    // MARK: - Internal Reading
+
+    private static func readHeaderAndEntries(handle: FileHandle) throws -> (PakHeader, [FileEntry]) {
+        let header = try readHeader(handle: handle)
+        let entries = try readFileList(handle: handle, header: header)
+        return (header, entries)
+    }
+
+    private static func readFileEntries(handle: FileHandle) throws -> [FileEntry] {
+        let header = try readHeader(handle: handle)
+        return try readFileList(handle: handle, header: header)
+    }
+
+    private static func readHeader(handle: FileHandle) throws -> PakHeader {
+        handle.seek(toFileOffset: 0)
+        guard let sigData = try handle.read(upToCount: 4),
+              sigData.count == 4 else {
+            throw PakError.readError("Cannot read signature")
+        }
+
+        guard Array(sigData) == signature else {
+            throw PakError.invalidSignature
+        }
+
+        guard let headerData = try handle.read(upToCount: headerSize),
+              headerData.count == headerSize else {
+            throw PakError.readError("Cannot read header")
+        }
+
+        let version = headerData.readUInt32(at: 0)
+        guard version == 18 || version == 16 || version == 15 else {
+            throw PakError.unsupportedVersion(version)
+        }
+
+        let fileListOffset = headerData.readUInt64(at: 4)
+        let fileListSize   = headerData.readUInt32(at: 12)
+        let flags          = headerData[16]
+        let priority       = headerData[17]
+        let md5            = headerData[18..<34]
+        let numParts       = headerData.readUInt16(at: 34)
+
+        return PakHeader(
+            version: version,
+            fileListOffset: fileListOffset,
+            fileListSize: fileListSize,
+            flags: flags,
+            priority: priority,
+            md5: Data(md5),
+            numParts: numParts
+        )
+    }
+
+    private static func readFileList(handle: FileHandle, header: PakHeader) throws -> [FileEntry] {
+        handle.seek(toFileOffset: header.fileListOffset)
+
+        // V18 file list: first 4 bytes = numFiles, next 4 bytes = compressedSize
+        guard let preamble = try handle.read(upToCount: 8),
+              preamble.count == 8 else {
+            throw PakError.fileListReadFailed
+        }
+
+        let numFiles = Int(preamble.readUInt32(at: 0))
+        let compressedSize = Int(preamble.readUInt32(at: 4))
+
+        guard numFiles > 0, numFiles < 1_000_000 else {
+            throw PakError.fileListReadFailed
+        }
+
+        guard let compressedData = try handle.read(upToCount: compressedSize),
+              compressedData.count == compressedSize else {
+            throw PakError.fileListReadFailed
+        }
+
+        let expectedSize = numFiles * fileEntrySize
+        let entryData: Data
+
+        if compressedSize == expectedSize {
+            // Data is not compressed
+            entryData = compressedData
+        } else {
+            // Decompress - use LZ4 frame if Solid, raw LZ4 block otherwise
+            if header.isSolid {
+                guard let decompressed = decompress(compressedData, expectedSize: expectedSize, algorithm: COMPRESSION_LZ4) else {
+                    // Fall back to raw LZ4
+                    guard let rawDecompressed = decompress(compressedData, expectedSize: expectedSize, algorithm: COMPRESSION_LZ4_RAW) else {
+                        throw PakError.decompressionFailed
+                    }
+                    entryData = rawDecompressed
+                }
+                entryData = decompressed
+            } else {
+                guard let decompressed = decompress(compressedData, expectedSize: expectedSize, algorithm: COMPRESSION_LZ4_RAW) else {
+                    // Fall back to frame LZ4
+                    guard let frameDecompressed = decompress(compressedData, expectedSize: expectedSize, algorithm: COMPRESSION_LZ4) else {
+                        throw PakError.decompressionFailed
+                    }
+                    entryData = frameDecompressed
+                }
+                entryData = decompressed
+            }
+        }
+
+        // Parse file entries
+        var entries: [FileEntry] = []
+        entries.reserveCapacity(numFiles)
+
+        for i in 0..<numFiles {
+            let base = i * fileEntrySize
+            guard base + fileEntrySize <= entryData.count else { break }
+
+            let nameData = entryData[base..<(base + 256)]
+            let name = String(data: Data(nameData), encoding: .utf8)?
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\0")) ?? ""
+
+            let offsetLow  = UInt64(entryData.readUInt32(at: base + 256))
+            let offsetHigh = UInt64(entryData.readUInt16(at: base + 260))
+            let offset     = offsetLow | (offsetHigh << 32)
+
+            let archivePart      = entryData[base + 262]
+            let flags            = entryData[base + 263]
+            let sizeOnDisk       = entryData.readUInt32(at: base + 264)
+            let uncompressedSize = entryData.readUInt32(at: base + 268)
+
+            entries.append(FileEntry(
+                name: name,
+                offset: offset,
+                archivePart: archivePart,
+                flags: flags,
+                sizeOnDisk: sizeOnDisk,
+                uncompressedSize: uncompressedSize
+            ))
+        }
+
+        return entries
+    }
+
+    private static func readFileData(handle: FileHandle, entry: FileEntry, header: PakHeader) throws -> Data {
+        handle.seek(toFileOffset: entry.offset)
+
+        guard let compressedData = try handle.read(upToCount: Int(entry.sizeOnDisk)),
+              compressedData.count == Int(entry.sizeOnDisk) else {
+            throw PakError.readError("Could not read file data for \(entry.name)")
+        }
+
+        if entry.sizeOnDisk == entry.uncompressedSize {
+            return compressedData
+        }
+
+        let algorithm: compression_algorithm
+        switch entry.compressionMethod {
+        case .none:
+            return compressedData
+        case .zlib:
+            algorithm = COMPRESSION_ZLIB
+        case .lz4:
+            algorithm = header.isSolid ? COMPRESSION_LZ4 : COMPRESSION_LZ4_RAW
+        }
+
+        guard let decompressed = decompress(compressedData, expectedSize: Int(entry.uncompressedSize), algorithm: algorithm) else {
+            throw PakError.decompressionFailed
+        }
+
+        return decompressed
+    }
+
+    // MARK: - Helpers
+
+    private static func isMetaLsx(path: String) -> Bool {
+        let normalized = path.replacingOccurrences(of: "\\", with: "/")
+        return normalized.hasPrefix("Mods/") && normalized.hasSuffix("/meta.lsx")
+    }
+
+    private static func decompress(_ data: Data, expectedSize: Int, algorithm: compression_algorithm) -> Data? {
+        // Allow generous buffer (expected size + some slack)
+        let bufferSize = max(expectedSize, data.count * 4)
+        var decompressed = Data(count: bufferSize)
+
+        let result = decompressed.withUnsafeMutableBytes { destBuffer in
+            data.withUnsafeBytes { srcBuffer in
+                guard let destPtr = destBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                      let srcPtr = srcBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                    return 0
+                }
+                return compression_decode_buffer(
+                    destPtr, bufferSize,
+                    srcPtr, data.count,
+                    nil,
+                    algorithm
+                )
+            }
+        }
+
+        guard result > 0 else { return nil }
+        decompressed.count = result
+        return decompressed
+    }
+}
+
+// MARK: - Data Binary Reading Extensions
+
+extension Data {
+    func readUInt16(at offset: Int) -> UInt16 {
+        let range = offset..<(offset + 2)
+        guard range.upperBound <= count else { return 0 }
+        return self[range].withUnsafeBytes { $0.load(as: UInt16.self).littleEndian }
+    }
+
+    func readUInt32(at offset: Int) -> UInt32 {
+        let range = offset..<(offset + 4)
+        guard range.upperBound <= count else { return 0 }
+        return self[range].withUnsafeBytes { $0.load(as: UInt32.self).littleEndian }
+    }
+
+    func readUInt64(at offset: Int) -> UInt64 {
+        let range = offset..<(offset + 8)
+        guard range.upperBound <= count else { return 0 }
+        return self[range].withUnsafeBytes { $0.load(as: UInt64.self).littleEndian }
+    }
+
+    func readInt64(at offset: Int) -> Int64 {
+        let range = offset..<(offset + 8)
+        guard range.upperBound <= count else { return 0 }
+        return self[range].withUnsafeBytes { $0.load(as: Int64.self).littleEndian }
+    }
+}

--- a/Sources/BG3MacModManager/Services/ProfileService.swift
+++ b/Sources/BG3MacModManager/Services/ProfileService.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Saves and loads mod profiles (named load order configurations).
+final class ProfileService {
+
+    enum ProfileError: Error, LocalizedError {
+        case saveFailed(String)
+        case loadFailed(String)
+        case profileNotFound(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .saveFailed(let msg): return "Failed to save profile: \(msg)"
+            case .loadFailed(let msg): return "Failed to load profile: \(msg)"
+            case .profileNotFound(let name): return "Profile not found: \(name)"
+            }
+        }
+    }
+
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    // MARK: - Save
+
+    /// Save a profile with the current active mods and their load order.
+    func save(name: String, activeMods: [ModInfo]) throws -> ModProfile {
+        let entries = activeMods.map { ModProfileEntry(from: $0) }
+        let profile = ModProfile(
+            name: name,
+            activeModUUIDs: activeMods.map(\.uuid),
+            mods: entries
+        )
+
+        let data = try encoder.encode(profile)
+        let url = profileURL(for: profile)
+        try FileLocations.ensureDirectoryExists(FileLocations.profilesDirectory)
+        try data.write(to: url, options: .atomic)
+
+        return profile
+    }
+
+    // MARK: - Load
+
+    /// List all saved profiles.
+    func listProfiles() throws -> [ModProfile] {
+        let dir = FileLocations.profilesDirectory
+        guard FileManager.default.fileExists(atPath: dir.path) else { return [] }
+
+        let files = try FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+        let jsonFiles = files.filter { $0.pathExtension == "json" }
+
+        return jsonFiles.compactMap { url in
+            guard let data = try? Data(contentsOf: url),
+                  let profile = try? decoder.decode(ModProfile.self, from: data) else {
+                return nil
+            }
+            return profile
+        }.sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    /// Load a specific profile by ID.
+    func load(id: UUID) throws -> ModProfile {
+        let profiles = try listProfiles()
+        guard let profile = profiles.first(where: { $0.id == id }) else {
+            throw ProfileError.profileNotFound(id.uuidString)
+        }
+        return profile
+    }
+
+    // MARK: - Delete
+
+    /// Delete a profile.
+    func delete(profile: ModProfile) throws {
+        let url = profileURL(for: profile)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+
+    // MARK: - Export / Import
+
+    /// Export a profile to a specific URL (for sharing).
+    func export(profile: ModProfile, to url: URL) throws {
+        let data = try encoder.encode(profile)
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Import a profile from a JSON file.
+    func importProfile(from url: URL) throws -> ModProfile {
+        let data = try Data(contentsOf: url)
+        let profile = try decoder.decode(ModProfile.self, from: data)
+
+        // Save to profiles directory
+        let savedData = try encoder.encode(profile)
+        let savedURL = profileURL(for: profile)
+        try FileLocations.ensureDirectoryExists(FileLocations.profilesDirectory)
+        try savedData.write(to: savedURL, options: .atomic)
+
+        return profile
+    }
+
+    // MARK: - Helpers
+
+    private func profileURL(for profile: ModProfile) -> URL {
+        let sanitizedName = profile.name
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+        return FileLocations.profilesDirectory
+            .appendingPathComponent("\(sanitizedName)-\(profile.id.uuidString).json")
+    }
+}

--- a/Sources/BG3MacModManager/Services/ScriptExtenderService.swift
+++ b/Sources/BG3MacModManager/Services/ScriptExtenderService.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Detects and manages bg3se-macos (Script Extender for macOS) integration.
+final class ScriptExtenderService {
+
+    struct SEStatus {
+        var isInstalled: Bool
+        var isDeployed: Bool
+        var dylibPath: URL?
+        var logsAvailable: Bool
+        var latestLogPath: URL?
+    }
+
+    // MARK: - Detection
+
+    /// Check the current Script Extender installation status.
+    func checkStatus() -> SEStatus {
+        let fm = FileManager.default
+
+        // Check deployed dylib in game app bundle
+        let deployedPath = FileLocations.seDeployedDylib
+        let isDeployed = fm.fileExists(atPath: deployedPath.path)
+
+        // Check logs directory
+        let logsDir = FileLocations.seLogsDirectory
+        let logsExist = fm.fileExists(atPath: logsDir.path)
+
+        // Check latest log
+        let latestLog = FileLocations.seLatestLog
+        let latestLogExists = fm.fileExists(atPath: latestLog.path)
+
+        // Also check if SE data directory exists (created on first run)
+        let seDataDir = FileLocations.seDataDirectory
+        let seDataExists = fm.fileExists(atPath: seDataDir.path)
+
+        return SEStatus(
+            isInstalled: isDeployed || seDataExists,
+            isDeployed: isDeployed,
+            dylibPath: isDeployed ? deployedPath : nil,
+            logsAvailable: logsExist && latestLogExists,
+            latestLogPath: latestLogExists ? latestLog : nil
+        )
+    }
+
+    /// Read the latest SE log file contents.
+    func readLatestLog(maxBytes: Int = 100_000) -> String? {
+        let logPath = FileLocations.seLatestLog
+        guard FileManager.default.fileExists(atPath: logPath.path),
+              let data = try? Data(contentsOf: logPath) else {
+            return nil
+        }
+
+        let readData: Data
+        if data.count > maxBytes {
+            readData = data[(data.count - maxBytes)...]
+        } else {
+            readData = data
+        }
+
+        return String(data: readData, encoding: .utf8)
+    }
+
+    /// Check if a specific mod requires the Script Extender.
+    func modRequiresScriptExtender(pakURL: URL) -> Bool {
+        PakReader.containsScriptExtender(at: pakURL)
+    }
+
+    // MARK: - SE Environment Variables
+
+    /// Environment variables that can be passed to bg3se-macos via the launch wrapper.
+    enum SEEnvironmentVar: String, CaseIterable {
+        case noHooks  = "BG3SE_NO_HOOKS"
+        case noNet    = "BG3SE_NO_NET"
+        case minimal  = "BG3SE_MINIMAL"
+
+        var description: String {
+            switch self {
+            case .noHooks:  return "Disable function hooks (debugging)"
+            case .noNet:    return "Disable networking features"
+            case .minimal:  return "Minimal mode (reduced functionality)"
+            }
+        }
+    }
+
+    /// Build the environment dictionary for launching with SE.
+    func buildEnvironment(noHooks: Bool = false, noNet: Bool = false, minimal: Bool = false) -> [String: String] {
+        var env: [String: String] = [:]
+        if noHooks { env[SEEnvironmentVar.noHooks.rawValue] = "1" }
+        if noNet   { env[SEEnvironmentVar.noNet.rawValue]   = "1" }
+        if minimal { env[SEEnvironmentVar.minimal.rawValue] = "1" }
+        return env
+    }
+}

--- a/Sources/BG3MacModManager/Utilities/FileLocations.swift
+++ b/Sources/BG3MacModManager/Utilities/FileLocations.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Central registry of all BG3-related file paths on macOS.
+enum FileLocations {
+
+    // MARK: - Larian Documents Root
+
+    static var larianDocuments: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Documents/Larian Studios/Baldur's Gate 3")
+    }
+
+    // MARK: - Mods
+
+    /// `~/Documents/Larian Studios/Baldur's Gate 3/Mods/`
+    static var modsFolder: URL {
+        larianDocuments.appendingPathComponent("Mods")
+    }
+
+    // MARK: - Player Profiles
+
+    /// `~/Documents/Larian Studios/Baldur's Gate 3/PlayerProfiles/Public/`
+    static var publicProfile: URL {
+        larianDocuments.appendingPathComponent("PlayerProfiles/Public")
+    }
+
+    /// `~/Documents/Larian Studios/Baldur's Gate 3/PlayerProfiles/Public/modsettings.lsx`
+    static var modSettingsFile: URL {
+        publicProfile.appendingPathComponent("modsettings.lsx")
+    }
+
+    /// `~/Documents/Larian Studios/Baldur's Gate 3/PlayerProfiles/Public/Savegames/Story/`
+    static var savegamesFolder: URL {
+        publicProfile.appendingPathComponent("Savegames/Story")
+    }
+
+    // MARK: - Game Installation (Steam)
+
+    static var steamApps: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Steam/steamapps")
+    }
+
+    /// `~/Library/Application Support/Steam/steamapps/common/Baldurs Gate 3/`
+    static var gameInstallation: URL {
+        steamApps.appendingPathComponent("common/Baldurs Gate 3")
+    }
+
+    /// `~/Library/Application Support/Steam/steamapps/common/Baldurs Gate 3/Data/`
+    static var gameData: URL {
+        gameInstallation.appendingPathComponent("Data")
+    }
+
+    /// `~/Library/Application Support/Steam/steamapps/common/Baldurs Gate 3/Baldur's Gate 3.app`
+    static var gameApp: URL {
+        gameInstallation.appendingPathComponent("Baldur's Gate 3.app")
+    }
+
+    static var gameExecutable: URL {
+        gameApp.appendingPathComponent("Contents/MacOS")
+    }
+
+    // MARK: - Script Extender (bg3se-macos)
+
+    /// Expected location of deployed SE dylib inside the game app bundle.
+    static var seDeployedDylib: URL {
+        gameExecutable.appendingPathComponent("libbg3se.dylib")
+    }
+
+    /// `~/Library/Application Support/BG3SE/`
+    static var seDataDirectory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/BG3SE")
+    }
+
+    /// `~/Library/Application Support/BG3SE/logs/`
+    static var seLogsDirectory: URL {
+        seDataDirectory.appendingPathComponent("logs")
+    }
+
+    static var seLatestLog: URL {
+        seLogsDirectory.appendingPathComponent("latest.log")
+    }
+
+    // MARK: - App Data
+
+    static var appSupportDirectory: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("BG3MacModManager")
+    }
+
+    static var backupsDirectory: URL {
+        appSupportDirectory.appendingPathComponent("Backups")
+    }
+
+    static var profilesDirectory: URL {
+        appSupportDirectory.appendingPathComponent("Profiles")
+    }
+
+    // MARK: - Helpers
+
+    /// Ensures a directory exists, creating it if necessary.
+    static func ensureDirectoryExists(_ url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    /// Returns true if the game appears to be installed.
+    static var isGameInstalled: Bool {
+        FileManager.default.fileExists(atPath: gameApp.path)
+    }
+
+    /// Returns true if the Mods folder exists.
+    static var modsFolderExists: Bool {
+        FileManager.default.fileExists(atPath: modsFolder.path)
+    }
+
+    /// Returns true if modsettings.lsx exists.
+    static var modSettingsExists: Bool {
+        FileManager.default.fileExists(atPath: modSettingsFile.path)
+    }
+}

--- a/Sources/BG3MacModManager/Utilities/Version64.swift
+++ b/Sources/BG3MacModManager/Utilities/Version64.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Encodes and decodes BG3's Version64 format.
+///
+/// BG3 stores version numbers as a single Int64 value with bit-packed components:
+/// - Bits 55-63: Major (9 bits, max 511)
+/// - Bits 47-54: Minor (8 bits, max 255)
+/// - Bits 31-46: Revision (16 bits, max 65535)
+/// - Bits 0-30:  Build (31 bits)
+struct Version64: Codable, Equatable, Comparable, CustomStringConvertible {
+    let major: Int
+    let minor: Int
+    let revision: Int
+    let build: Int
+
+    /// The raw Int64 value as used by BG3.
+    var rawValue: Int64 {
+        var value: Int64 = 0
+        value |= Int64(major) << 55
+        value |= Int64(minor) << 47
+        value |= Int64(revision) << 31
+        value |= Int64(build)
+        return value
+    }
+
+    /// Human-readable version string, e.g. "1.0.0.0".
+    var description: String {
+        "\(major).\(minor).\(revision).\(build)"
+    }
+
+    init(major: Int = 0, minor: Int = 0, revision: Int = 0, build: Int = 0) {
+        self.major = major
+        self.minor = minor
+        self.revision = revision
+        self.build = build
+    }
+
+    /// Decode from a BG3 Version64 raw Int64 value.
+    init(rawValue: Int64) {
+        self.major    = Int((rawValue >> 55) & 0x1FF)    // 9 bits
+        self.minor    = Int((rawValue >> 47) & 0xFF)     // 8 bits
+        self.revision = Int((rawValue >> 31) & 0xFFFF)   // 16 bits
+        self.build    = Int(rawValue & 0x7FFFFFFF)       // 31 bits
+    }
+
+    /// Parse from a raw string representation of the Int64 value.
+    init?(rawString: String) {
+        guard let value = Int64(rawString) else { return nil }
+        self.init(rawValue: value)
+    }
+
+    /// Parse from a dotted version string like "1.0.0.0".
+    init?(versionString: String) {
+        let parts = versionString.split(separator: ".").compactMap { Int($0) }
+        guard parts.count >= 1 else { return nil }
+        self.major    = parts[0]
+        self.minor    = parts.count > 1 ? parts[1] : 0
+        self.revision = parts.count > 2 ? parts[2] : 0
+        self.build    = parts.count > 3 ? parts[3] : 0
+    }
+
+    static func < (lhs: Version64, rhs: Version64) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/Sources/BG3MacModManager/Views/BackupManagerView.swift
+++ b/Sources/BG3MacModManager/Views/BackupManagerView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+/// View for managing modsettings.lsx backups.
+struct BackupManagerView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var showingRestoreConfirmation = false
+    @State private var selectedBackup: BackupService.Backup?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Backups")
+                    .font(.title2.bold())
+                Spacer()
+                Button {
+                    createBackup()
+                } label: {
+                    Label("Create Backup", systemImage: "plus")
+                }
+            }
+            .padding()
+
+            Divider()
+
+            if appState.backups.isEmpty {
+                emptyState
+            } else {
+                backupList
+            }
+        }
+        .confirmationDialog(
+            "Restore Backup?",
+            isPresented: $showingRestoreConfirmation,
+            presenting: selectedBackup
+        ) { backup in
+            Button("Restore", role: .destructive) {
+                Task { await appState.restoreBackup(backup) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { backup in
+            Text("This will replace your current modsettings.lsx with the backup from \(backup.displayName). A safety backup will be created first.")
+        }
+    }
+
+    private var backupList: some View {
+        List {
+            ForEach(appState.backups) { backup in
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(backup.displayName)
+                            .font(.headline)
+                        Text(ByteCountFormatter.string(fromByteCount: Int64(backup.fileSize), countStyle: .file))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    Button("Restore") {
+                        selectedBackup = backup
+                        showingRestoreConfirmation = true
+                    }
+
+                    Button(role: .destructive) {
+                        Task { await appState.deleteBackup(backup) }
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text("No Backups")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Text("Backups are created automatically when you save mod settings. You can also create manual backups.")
+                .font(.body)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 350)
+            Button("Create Backup Now") {
+                createBackup()
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+    }
+
+    private func createBackup() {
+        do {
+            try appState.backupService.backupModSettings()
+            Task { await appState.refreshBackups() }
+            appState.statusMessage = "Backup created"
+        } catch {
+            appState.errorMessage = error.localizedDescription
+            appState.showError = true
+        }
+    }
+}

--- a/Sources/BG3MacModManager/Views/ModDetailView.swift
+++ b/Sources/BG3MacModManager/Views/ModDetailView.swift
@@ -1,0 +1,248 @@
+import SwiftUI
+
+/// Detail panel showing full mod information.
+struct ModDetailView: View {
+    let mod: ModInfo
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                // Header
+                header
+
+                Divider()
+
+                // Metadata
+                metadataSection
+
+                // Dependencies
+                if !mod.dependencies.isEmpty {
+                    Divider()
+                    dependenciesSection
+                }
+
+                // Tags
+                if !mod.tags.isEmpty {
+                    Divider()
+                    tagsSection
+                }
+
+                // File Info
+                Divider()
+                fileInfoSection
+
+                Spacer()
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(mod.name)
+                    .font(.title2.bold())
+
+                if mod.requiresScriptExtender {
+                    Text("Script Extender")
+                        .font(.caption.bold())
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.orange, in: RoundedRectangle(cornerRadius: 4))
+                }
+            }
+
+            if mod.author != "Unknown" {
+                Text("by \(mod.author)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text("Version \(mod.version.description)")
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Metadata
+
+    private var metadataSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if !mod.modDescription.isEmpty {
+                Text(mod.modDescription)
+                    .font(.body)
+            }
+
+            detailRow("UUID", mod.uuid, monospaced: true, copyable: true)
+            detailRow("Folder", mod.folder, copyable: true)
+            detailRow("Version64", String(mod.version64), monospaced: true)
+            detailRow("Source", mod.metadataSource.rawValue)
+        }
+    }
+
+    // MARK: - Dependencies
+
+    private var dependenciesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Dependencies")
+                .font(.headline)
+
+            let missing = appState.missingDependencies(for: mod)
+
+            ForEach(mod.dependencies) { dep in
+                HStack {
+                    Image(systemName: missing.contains(where: { $0.uuid == dep.uuid }) ?
+                          "xmark.circle.fill" : "checkmark.circle.fill")
+                        .foregroundStyle(missing.contains(where: { $0.uuid == dep.uuid }) ? .red : .green)
+
+                    VStack(alignment: .leading) {
+                        Text(dep.name.isEmpty ? dep.uuid : dep.name)
+                            .font(.body)
+                        if !dep.folder.isEmpty {
+                            Text(dep.folder)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            if !missing.isEmpty {
+                Text("Missing \(missing.count) required mod(s)")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    // MARK: - Tags
+
+    private var tagsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Tags")
+                .font(.headline)
+
+            FlowLayout(spacing: 6) {
+                ForEach(mod.tags, id: \.self) { tag in
+                    Text(tag)
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Color.accentColor.opacity(0.15), in: RoundedRectangle(cornerRadius: 4))
+                }
+            }
+        }
+    }
+
+    // MARK: - File Info
+
+    private var fileInfoSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("File Info")
+                .font(.headline)
+
+            if let fileName = mod.pakFileName {
+                detailRow("File", fileName, copyable: true)
+            }
+            if let filePath = mod.pakFilePath {
+                HStack {
+                    Text("Path")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 60, alignment: .trailing)
+                    Text(filePath.path)
+                        .font(.caption.monospaced())
+                        .lineLimit(2)
+                        .textSelection(.enabled)
+                    Spacer()
+                    Button {
+                        NSWorkspace.shared.activateFileViewerSelecting([filePath])
+                    } label: {
+                        Image(systemName: "arrow.right.circle")
+                    }
+                    .buttonStyle(.plain)
+                    .help("Reveal in Finder")
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func detailRow(_ label: String, _ value: String, monospaced: Bool = false, copyable: Bool = false) -> some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 60, alignment: .trailing)
+            if monospaced {
+                Text(value)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+            } else {
+                Text(value)
+                    .font(.caption)
+                    .textSelection(.enabled)
+            }
+            Spacer()
+            if copyable {
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(value, forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .font(.caption2)
+                }
+                .buttonStyle(.plain)
+                .help("Copy to clipboard")
+            }
+        }
+    }
+}
+
+// MARK: - Flow Layout for Tags
+
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let result = layout(proposal: proposal, subviews: subviews)
+        return result.size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = layout(proposal: proposal, subviews: subviews)
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y),
+                                  proposal: .unspecified)
+        }
+    }
+
+    private func layout(proposal: ProposedViewSize, subviews: Subviews) -> (size: CGSize, positions: [CGPoint]) {
+        let maxWidth = proposal.width ?? .infinity
+        var positions: [CGPoint] = []
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        var maxX: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentX + size.width > maxWidth, currentX > 0 {
+                currentX = 0
+                currentY += lineHeight + spacing
+                lineHeight = 0
+            }
+            positions.append(CGPoint(x: currentX, y: currentY))
+            lineHeight = max(lineHeight, size.height)
+            currentX += size.width + spacing
+            maxX = max(maxX, currentX)
+        }
+
+        return (CGSize(width: maxX, height: currentY + lineHeight), positions)
+    }
+}

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+/// Main mod management view with active (load order) and inactive mod lists.
+struct ModListView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var searchText = ""
+    @State private var draggedMod: ModInfo?
+
+    var body: some View {
+        HSplitView {
+            // Left: Active + Inactive mod lists
+            VStack(spacing: 0) {
+                activeModsSection
+                Divider()
+                inactiveModsSection
+            }
+            .frame(minWidth: 350)
+
+            // Right: Detail panel
+            modDetailPanel
+                .frame(minWidth: 280, idealWidth: 320)
+        }
+        .searchable(text: $searchText, prompt: "Filter mods...")
+    }
+
+    // MARK: - Active Mods
+
+    private var activeModsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Label("Active Mods (\(appState.activeMods.count))", systemImage: "checkmark.circle.fill")
+                    .font(.headline)
+                    .foregroundStyle(.green)
+                Spacer()
+                Menu {
+                    Button("Activate All") { appState.activateAll() }
+                    Button("Deactivate All") { appState.deactivateAll() }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            List(selection: $appState.selectedModID) {
+                ForEach(filteredActiveMods) { mod in
+                    ModRowView(mod: mod, isActive: true)
+                        .tag(mod.uuid)
+                        .contextMenu {
+                            if !mod.isBasicGameModule {
+                                Button("Deactivate") { appState.deactivateMod(mod) }
+                            }
+                            Divider()
+                            Button("Copy UUID") {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(mod.uuid, forType: .string)
+                            }
+                        }
+                }
+                .onMove { source, destination in
+                    appState.moveActiveMod(from: source, to: destination)
+                }
+            }
+            .listStyle(.inset(alternatesRowBackgrounds: true))
+        }
+    }
+
+    // MARK: - Inactive Mods
+
+    private var inactiveModsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Label("Inactive Mods (\(appState.inactiveMods.count))", systemImage: "xmark.circle")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            List(selection: $appState.selectedModID) {
+                ForEach(filteredInactiveMods) { mod in
+                    ModRowView(mod: mod, isActive: false)
+                        .tag(mod.uuid)
+                        .contextMenu {
+                            Button("Activate") { appState.activateMod(mod) }
+                            Divider()
+                            Button("Copy UUID") {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(mod.uuid, forType: .string)
+                            }
+                        }
+                }
+            }
+            .listStyle(.inset(alternatesRowBackgrounds: true))
+        }
+    }
+
+    // MARK: - Detail Panel
+
+    @ViewBuilder
+    private var modDetailPanel: some View {
+        if let mod = appState.selectedMod {
+            ModDetailView(mod: mod)
+        } else {
+            VStack {
+                Image(systemName: "puzzlepiece.extension")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.secondary)
+                Text("Select a mod to view details")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: - Filtering
+
+    private var filteredActiveMods: [ModInfo] {
+        guard !searchText.isEmpty else { return appState.activeMods }
+        return appState.activeMods.filter { matchesSearch($0) }
+    }
+
+    private var filteredInactiveMods: [ModInfo] {
+        guard !searchText.isEmpty else { return appState.inactiveMods }
+        return appState.inactiveMods.filter { matchesSearch($0) }
+    }
+
+    private func matchesSearch(_ mod: ModInfo) -> Bool {
+        let query = searchText.lowercased()
+        return mod.name.lowercased().contains(query)
+            || mod.author.lowercased().contains(query)
+            || mod.folder.lowercased().contains(query)
+            || mod.tags.contains { $0.lowercased().contains(query) }
+    }
+}

--- a/Sources/BG3MacModManager/Views/ModRowView.swift
+++ b/Sources/BG3MacModManager/Views/ModRowView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// A single row in the mod list showing mod name, author, and status indicators.
+struct ModRowView: View {
+    let mod: ModInfo
+    let isActive: Bool
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        HStack(spacing: 10) {
+            // Load order number (for active mods)
+            if isActive, let index = appState.activeMods.firstIndex(where: { $0.uuid == mod.uuid }) {
+                Text("\(index + 1)")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24, alignment: .trailing)
+            }
+
+            // Mod info
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(mod.name)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+
+                    if mod.requiresScriptExtender {
+                        Text("SE")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.orange, in: RoundedRectangle(cornerRadius: 3))
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    if mod.author != "Unknown" {
+                        Text(mod.author)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Text("v\(mod.version.description)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.tertiary)
+
+                    if mod.metadataSource == .filename {
+                        Text("(no metadata)")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Warnings
+            if !appState.missingDependencies(for: mod).isEmpty {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.yellow)
+                    .help("Missing dependencies")
+            }
+
+            // Activate/Deactivate button
+            if isActive && !mod.isBasicGameModule {
+                Button {
+                    appState.deactivateMod(mod)
+                } label: {
+                    Image(systemName: "minus.circle")
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.plain)
+                .help("Deactivate")
+            } else if !isActive {
+                Button {
+                    appState.activateMod(mod)
+                } label: {
+                    Image(systemName: "plus.circle")
+                        .foregroundStyle(.green)
+                }
+                .buttonStyle(.plain)
+                .help("Activate")
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/Sources/BG3MacModManager/Views/ProfileManagerView.swift
+++ b/Sources/BG3MacModManager/Views/ProfileManagerView.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+
+/// View for managing saved mod profiles (named load order configurations).
+struct ProfileManagerView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var newProfileName = ""
+    @State private var showingSaveSheet = false
+    @State private var showingImportDialog = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Mod Profiles")
+                    .font(.title2.bold())
+                Spacer()
+                Button("Save Current...") {
+                    showingSaveSheet = true
+                }
+                Button {
+                    importProfile()
+                } label: {
+                    Label("Import", systemImage: "square.and.arrow.down")
+                }
+            }
+            .padding()
+
+            Divider()
+
+            if appState.profiles.isEmpty {
+                emptyState
+            } else {
+                profileList
+            }
+        }
+        .sheet(isPresented: $showingSaveSheet) {
+            saveProfileSheet
+        }
+    }
+
+    // MARK: - Profile List
+
+    private var profileList: some View {
+        List {
+            ForEach(appState.profiles) { profile in
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(profile.name)
+                            .font(.headline)
+                        Text("\(profile.activeModUUIDs.count) mods")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("Saved \(profile.updatedAt, style: .relative) ago")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+
+                    Spacer()
+
+                    Button("Load") {
+                        Task { await appState.loadProfile(profile) }
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button {
+                        exportProfile(profile)
+                    } label: {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                    .help("Export profile")
+
+                    Button(role: .destructive) {
+                        Task { await appState.deleteProfile(profile) }
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .help("Delete profile")
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "person.2")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text("No Saved Profiles")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Text("Save your current mod configuration as a profile to quickly switch between setups.")
+                .font(.body)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 350)
+            Button("Save Current Configuration...") {
+                showingSaveSheet = true
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+    }
+
+    // MARK: - Save Sheet
+
+    private var saveProfileSheet: some View {
+        VStack(spacing: 16) {
+            Text("Save Profile")
+                .font(.headline)
+
+            TextField("Profile Name", text: $newProfileName)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 300)
+
+            Text("This will save your current \(appState.activeMods.count) active mods and their load order.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Button("Cancel") {
+                    showingSaveSheet = false
+                    newProfileName = ""
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Save") {
+                    Task {
+                        await appState.saveProfile(name: newProfileName)
+                        showingSaveSheet = false
+                        newProfileName = ""
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(newProfileName.isEmpty)
+            }
+        }
+        .padding(24)
+    }
+
+    // MARK: - Import / Export
+
+    private func importProfile() {
+        let panel = NSOpenPanel()
+        panel.title = "Import Profile"
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+
+        if panel.runModal() == .OK, let url = panel.url {
+            Task {
+                do {
+                    _ = try appState.profileService.importProfile(from: url)
+                    await appState.refreshProfiles()
+                } catch {
+                    appState.errorMessage = error.localizedDescription
+                    appState.showError = true
+                }
+            }
+        }
+    }
+
+    private func exportProfile(_ profile: ModProfile) {
+        let panel = NSSavePanel()
+        panel.title = "Export Profile"
+        panel.nameFieldStringValue = "\(profile.name).json"
+        panel.allowedContentTypes = [.json]
+
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                try appState.profileService.export(profile: profile, to: url)
+            } catch {
+                appState.errorMessage = error.localizedDescription
+                appState.showError = true
+            }
+        }
+    }
+}

--- a/Sources/BG3MacModManager/Views/SEStatusView.swift
+++ b/Sources/BG3MacModManager/Views/SEStatusView.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+/// View showing Script Extender (bg3se-macos) installation status and controls.
+struct SEStatusView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var logContent: String?
+    @State private var showingLog = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                Text("Script Extender (bg3se-macos)")
+                    .font(.title2.bold())
+
+                if let status = appState.seStatus {
+                    statusCard(status)
+                    installationGuide(status)
+                    if status.isInstalled {
+                        seModsSection
+                    }
+                    logSection(status)
+                } else {
+                    ProgressView("Checking status...")
+                }
+            }
+            .padding()
+        }
+        .onAppear {
+            appState.refreshSEStatus()
+        }
+    }
+
+    // MARK: - Status Card
+
+    private func statusCard(_ status: ScriptExtenderService.SEStatus) -> some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Image(systemName: status.isInstalled ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .font(.title)
+                        .foregroundStyle(status.isInstalled ? .green : .red)
+
+                    VStack(alignment: .leading) {
+                        Text(status.isInstalled ? "Script Extender Detected" : "Script Extender Not Found")
+                            .font(.headline)
+                        Text(status.isDeployed ?
+                             "Dylib deployed to game bundle" :
+                             "libbg3se.dylib not found in game bundle")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if status.isDeployed, let path = status.dylibPath {
+                    HStack {
+                        Text("Dylib:")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(path.path)
+                            .font(.caption.monospaced())
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(4)
+        }
+    }
+
+    // MARK: - Installation Guide
+
+    @ViewBuilder
+    private func installationGuide(_ status: ScriptExtenderService.SEStatus) -> some View {
+        if !status.isInstalled {
+            GroupBox("Installation Guide") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("bg3se-macos enables Lua-scripted mods on macOS. To install:")
+                        .font(.body)
+
+                    guideStep(1, "Clone the repository:",
+                              "git clone --recursive https://github.com/tdimino/bg3se-macos.git")
+                    guideStep(2, "Build:",
+                              "cd bg3se-macos && mkdir -p build && cd build && cmake .. && cmake --build .")
+                    guideStep(3, "Deploy the dylib:",
+                              "./scripts/deploy.sh")
+                    guideStep(4, "Set Steam launch options to:",
+                              "/path/to/bg3se-macos/scripts/bg3w.sh %command%")
+
+                    Text("See the bg3se-macos README for full instructions.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 4)
+                }
+                .padding(4)
+            }
+        }
+    }
+
+    private func guideStep(_ number: Int, _ text: String, _ code: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(number). \(text)")
+                .font(.body)
+            Text(code)
+                .font(.caption.monospaced())
+                .padding(6)
+                .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 4))
+                .textSelection(.enabled)
+        }
+    }
+
+    // MARK: - SE Mods
+
+    private var seModsSection: some View {
+        GroupBox("Script Extender Mods") {
+            let seMods = (appState.activeMods + appState.inactiveMods).filter(\.requiresScriptExtender)
+
+            if seMods.isEmpty {
+                Text("No SE mods detected")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .padding(4)
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(seMods) { mod in
+                        HStack {
+                            Image(systemName: appState.activeMods.contains(where: { $0.uuid == mod.uuid }) ?
+                                  "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(appState.activeMods.contains(where: { $0.uuid == mod.uuid }) ?
+                                                 .green : .secondary)
+                            Text(mod.name)
+                                .font(.body)
+                            Spacer()
+                            Text(appState.activeMods.contains(where: { $0.uuid == mod.uuid }) ? "Active" : "Inactive")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(4)
+            }
+        }
+    }
+
+    // MARK: - Log Section
+
+    @ViewBuilder
+    private func logSection(_ status: ScriptExtenderService.SEStatus) -> some View {
+        if status.logsAvailable {
+            GroupBox("Logs") {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Button("View Latest Log") {
+                            logContent = appState.seService.readLatestLog()
+                            showingLog = true
+                        }
+                        Button("Open Logs Folder") {
+                            appState.launchService.openSELogs()
+                        }
+                    }
+
+                    if showingLog, let content = logContent {
+                        ScrollView {
+                            Text(content)
+                                .font(.caption.monospaced())
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .frame(maxHeight: 300)
+                        .background(Color.primary.opacity(0.03))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                }
+                .padding(4)
+            }
+        }
+    }
+}

--- a/Sources/BG3MacModManager/Views/SettingsView.swift
+++ b/Sources/BG3MacModManager/Views/SettingsView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+/// App settings view (shown in Preferences window).
+struct SettingsView: View {
+    @EnvironmentObject var appState: AppState
+    @AppStorage("lockModSettingsAfterSave") var lockAfterSave = true
+    @AppStorage("autoBackupBeforeSave") var autoBackup = true
+    @AppStorage("backupRetentionDays") var backupRetentionDays = 30
+
+    var body: some View {
+        TabView {
+            generalSettings
+                .tabItem { Label("General", systemImage: "gear") }
+
+            pathSettings
+                .tabItem { Label("Paths", systemImage: "folder") }
+
+            seSettings
+                .tabItem { Label("Script Extender", systemImage: "terminal") }
+        }
+        .frame(width: 500, height: 350)
+        .padding()
+    }
+
+    // MARK: - General
+
+    private var generalSettings: some View {
+        Form {
+            Section("Saving") {
+                Toggle("Lock modsettings.lsx after saving", isOn: $lockAfterSave)
+                    .help("Prevents the game from overwriting your mod configuration")
+
+                Toggle("Auto-backup before saving", isOn: $autoBackup)
+                    .help("Creates a backup of modsettings.lsx before any changes")
+            }
+
+            Section("Backups") {
+                Picker("Keep backups for", selection: $backupRetentionDays) {
+                    Text("7 days").tag(7)
+                    Text("14 days").tag(14)
+                    Text("30 days").tag(30)
+                    Text("90 days").tag(90)
+                    Text("Forever").tag(0)
+                }
+
+                Button("Clean Old Backups") {
+                    guard backupRetentionDays > 0 else { return }
+                    try? appState.backupService.pruneBackups(olderThanDays: backupRetentionDays)
+                    Task { await appState.refreshBackups() }
+                }
+            }
+
+            Section("Game") {
+                HStack {
+                    Text("Game Status:")
+                    Text(appState.isGameInstalled ? "Installed" : "Not Found")
+                        .foregroundStyle(appState.isGameInstalled ? .green : .red)
+                }
+            }
+        }
+    }
+
+    // MARK: - Paths
+
+    private var pathSettings: some View {
+        Form {
+            Section("Detected Paths") {
+                pathRow("Mods Folder", FileLocations.modsFolder, exists: FileLocations.modsFolderExists)
+                pathRow("modsettings.lsx", FileLocations.modSettingsFile, exists: FileLocations.modSettingsExists)
+                pathRow("Game App", FileLocations.gameApp, exists: FileLocations.isGameInstalled)
+                pathRow("SE Dylib", FileLocations.seDeployedDylib,
+                        exists: FileManager.default.fileExists(atPath: FileLocations.seDeployedDylib.path))
+            }
+
+            Section("App Data") {
+                pathRow("Profiles", FileLocations.profilesDirectory, exists: true)
+                pathRow("Backups", FileLocations.backupsDirectory, exists: true)
+            }
+        }
+    }
+
+    private func pathRow(_ label: String, _ url: URL, exists: Bool) -> some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(label)
+                    .font(.body)
+                Text(url.path)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            Spacer()
+            Image(systemName: exists ? "checkmark.circle.fill" : "xmark.circle")
+                .foregroundStyle(exists ? .green : .red)
+        }
+    }
+
+    // MARK: - Script Extender
+
+    private var seSettings: some View {
+        Form {
+            if let status = appState.seStatus {
+                Section("Status") {
+                    HStack {
+                        Text("Installed:")
+                        Text(status.isInstalled ? "Yes" : "No")
+                            .foregroundStyle(status.isInstalled ? .green : .red)
+                    }
+                    HStack {
+                        Text("Deployed:")
+                        Text(status.isDeployed ? "Yes" : "No")
+                            .foregroundStyle(status.isDeployed ? .green : .red)
+                    }
+                }
+
+                if status.isInstalled {
+                    Section("Debug Options") {
+                        Text("These environment variables can be set via the bg3w.sh launch script.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        ForEach(ScriptExtenderService.SEEnvironmentVar.allCases, id: \.rawValue) { envVar in
+                            HStack {
+                                Text(envVar.rawValue)
+                                    .font(.body.monospaced())
+                                Spacer()
+                                Text(envVar.description)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            } else {
+                Text("Loading...")
+            }
+        }
+    }
+}

--- a/Tests/BG3MacModManagerTests/Version64Tests.swift
+++ b/Tests/BG3MacModManagerTests/Version64Tests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import BG3MacModManager
+
+final class Version64Tests: XCTestCase {
+
+    func testEncodeVersion_1_0_0_0() {
+        let version = Version64(major: 1, minor: 0, revision: 0, build: 0)
+        XCTAssertEqual(version.rawValue, 36028797018963968)
+    }
+
+    func testDecodeVersion_1_0_0_0() {
+        let version = Version64(rawValue: 36028797018963968)
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.revision, 0)
+        XCTAssertEqual(version.build, 0)
+    }
+
+    func testRoundTrip() {
+        let original = Version64(major: 4, minor: 7, revision: 1, build: 3)
+        let decoded = Version64(rawValue: original.rawValue)
+        XCTAssertEqual(original, decoded)
+    }
+
+    func testDescription() {
+        let version = Version64(major: 2, minor: 3, revision: 4, build: 5)
+        XCTAssertEqual(version.description, "2.3.4.5")
+    }
+
+    func testParseVersionString() {
+        let version = Version64(versionString: "1.2.3.4")
+        XCTAssertNotNil(version)
+        XCTAssertEqual(version?.major, 1)
+        XCTAssertEqual(version?.minor, 2)
+        XCTAssertEqual(version?.revision, 3)
+        XCTAssertEqual(version?.build, 4)
+    }
+
+    func testParseRawString() {
+        let version = Version64(rawString: "36028797018963968")
+        XCTAssertNotNil(version)
+        XCTAssertEqual(version?.major, 1)
+        XCTAssertEqual(version?.minor, 0)
+    }
+
+    func testComparable() {
+        let v1 = Version64(major: 1, minor: 0, revision: 0, build: 0)
+        let v2 = Version64(major: 2, minor: 0, revision: 0, build: 0)
+        XCTAssertTrue(v1 < v2)
+    }
+
+    func testPartialVersionString() {
+        let v1 = Version64(versionString: "1")
+        XCTAssertNotNil(v1)
+        XCTAssertEqual(v1?.major, 1)
+        XCTAssertEqual(v1?.minor, 0)
+
+        let v2 = Version64(versionString: "1.2")
+        XCTAssertNotNil(v2)
+        XCTAssertEqual(v2?.major, 1)
+        XCTAssertEqual(v2?.minor, 2)
+        XCTAssertEqual(v2?.revision, 0)
+    }
+}


### PR DESCRIPTION
Swift/SwiftUI application for managing Baldur's Gate 3 mods on macOS, inspired by LaughingLeader's Windows BG3ModManager. Zero external dependencies — builds with Swift Package Manager.

Core features:
- LSPK v18 .pak reader with LZ4/Zlib decompression for extracting mod metadata (meta.lsx) from Larian's proprietary archive format
- modsettings.lsx parser/writer with automatic GustavDev preservation and XML generation for the ModOrder and Mods sections
- Multi-strategy mod discovery: info.json → meta.lsx → filename fallback
- bg3se-macos (Script Extender) integration with status detection, SE mod flagging, log viewing, and installation guide
- Profile system for saving/loading named mod configurations as JSON
- Automatic backup/restore of modsettings.lsx with file locking support
- Game launch via Steam URL protocol
- Mod import from .pak files or ZIP archives

SwiftUI interface:
- Sidebar navigation (Mods, Profiles, Backups, Script Extender)
- Split-view mod list with active (reorderable) and inactive sections
- Mod detail panel with metadata, dependencies, tags, and file info
- Search/filter across mod name, author, folder, and tags
- Profile manager with save/load/import/export
- Backup manager with restore confirmation
- Settings with path detection and SE debug options
- Toolbar with save, refresh, and launch actions

https://claude.ai/code/session_0165DJByuL5gdRbqc8g5nj7P