### PR TITLE
fix: remove unsafeFlags from Package.swift that broke Xcode builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,10 +10,7 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "BG3MacModManager",
-            path: "Sources/BG3MacModManager",
-            swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-enable-upcoming-feature", "StrictConcurrency"], .when(configuration: .debug))
-            ]
+            path: "Sources/BG3MacModManager"
         ),
         .testTarget(
             name: "BG3MacModManagerTests",


### PR DESCRIPTION
The StrictConcurrency unsafeFlags caused Xcode to fail with "Unexpected input file" errors in .swiftpm/xcode/.

https://claude.ai/code/session_0165DJByuL5gdRbqc8g5nj7P