### PR TITLE
Fix app bundle by declaring Info.plist as a resource

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,10 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "BG3MacModManager",
-            path: "Sources/BG3MacModManager"
+            path: "Sources/BG3MacModManager",
+            resources: [
+                .copy("Info.plist")
+            ]
         ),
         .testTarget(
             name: "BG3MacModManagerTests",


### PR DESCRIPTION
SPM 5.9 requires non-source files in the target directory to be explicitly declared as resources or excluded. With `exclude`, Xcode couldn't find the Info.plist to configure the .app bundle it creates for the SwiftUI @main app, leaving the bundle without an executable. With `resources: [.copy("Info.plist")]`, SPM includes the file and Xcode can properly build the app bundle.

https://claude.ai/code/session_01Q79wkUCUjBBSxKz9bvFZg9