### PR TITLE
Add Phase 1 features: mod extraction, duplicate resolver, version gen…

### DIFF
--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
         case profiles = "Profiles"
         case backups = "Backups"
         case scriptExtender = "Script Extender"
+        case tools = "Tools"
 
         var id: String { rawValue }
 
@@ -18,6 +19,7 @@ struct ContentView: View {
             case .profiles: return "person.2"
             case .backups: return "clock.arrow.circlepath"
             case .scriptExtender: return "terminal"
+            case .tools: return "wrench.and.screwdriver"
             }
         }
     }
@@ -53,6 +55,10 @@ struct ContentView: View {
             let warningCount = appState.pendingSaveWarnings.filter { $0.severity == .warning }.count
             Text("Your mod configuration has \(criticalCount) critical issue(s) and \(warningCount) warning(s) that may cause the game to crash. Save anyway?")
         }
+        .sheet(isPresented: $appState.showDuplicateResolver) {
+            DuplicateResolverView()
+                .environmentObject(appState)
+        }
         .overlay(alignment: .bottom) {
             statusBar
         }
@@ -82,6 +88,8 @@ struct ContentView: View {
             BackupManagerView()
         case .scriptExtender:
             SEStatusView()
+        case .tools:
+            VersionGeneratorView()
         }
     }
 

--- a/Sources/BG3MacModManager/Views/DuplicateResolverView.swift
+++ b/Sources/BG3MacModManager/Views/DuplicateResolverView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+/// Sheet for resolving duplicate UUID conflicts by choosing which PAK files to keep.
+struct DuplicateResolverView: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Duplicate Mods Detected")
+                .font(.headline)
+
+            Text("The following mods share the same UUID. Only one copy of each should be kept to prevent the game from resetting your load order.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 450)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    ForEach(appState.duplicateGroups.indices, id: \.self) { groupIndex in
+                        duplicateGroupSection(appState.duplicateGroups[groupIndex])
+                    }
+                }
+                .padding(.horizontal)
+            }
+            .frame(maxHeight: 400)
+
+            HStack {
+                Spacer()
+                Button("Done") {
+                    appState.showDuplicateResolver = false
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 500)
+    }
+
+    private func duplicateGroupSection(_ mods: [ModInfo]) -> some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: "xmark.octagon.fill")
+                        .foregroundStyle(.red)
+                    Text(mods.first?.name ?? "Unknown")
+                        .font(.headline)
+                    Text("(\(mods.count) copies)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("UUID: \(mods.first?.uuid ?? "")")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+
+                ForEach(mods, id: \.pakFileName) { mod in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(mod.pakFileName ?? "Unknown file")
+                                .font(.body)
+
+                            if let pakURL = mod.pakFilePath {
+                                fileInfoRow(pakURL)
+                            }
+
+                            Text("Source: \(mod.metadataSource.rawValue)")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+
+                        Spacer()
+
+                        Button(role: .destructive) {
+                            Task { await appState.deletePakFile(for: mod) }
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        .disabled(mod.pakFilePath == nil)
+                        .help("Delete this PAK file from disk")
+                    }
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 8)
+                    .background(Color.primary.opacity(0.03), in: RoundedRectangle(cornerRadius: 4))
+                }
+            }
+            .padding(4)
+        }
+    }
+
+    private func fileInfoRow(_ url: URL) -> some View {
+        HStack(spacing: 12) {
+            if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) {
+                if let size = attrs[.size] as? Int64 {
+                    Text(ByteCountFormatter.string(fromByteCount: size, countStyle: .file))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if let date = attrs[.modificationDate] as? Date {
+                    Text(date, style: .date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -107,6 +107,14 @@ struct ModListView: View {
                             .font(.caption2)
                             .buttonStyle(.bordered)
                         }
+
+                        if warning.category == .duplicateUUID {
+                            Button("Resolve...") {
+                                appState.detectDuplicateGroups()
+                            }
+                            .font(.caption2)
+                            .buttonStyle(.bordered)
+                        }
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)
@@ -153,6 +161,12 @@ struct ModListView: View {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(mod.uuid, forType: .string)
                             }
+                            if mod.pakFilePath != nil {
+                                Divider()
+                                Button("Extract to Folder...") {
+                                    appState.extractMod(mod)
+                                }
+                            }
                         }
                 }
                 .onMove { source, destination in
@@ -186,6 +200,12 @@ struct ModListView: View {
                             Button("Copy UUID") {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(mod.uuid, forType: .string)
+                            }
+                            if mod.pakFilePath != nil {
+                                Divider()
+                                Button("Extract to Folder...") {
+                                    appState.extractMod(mod)
+                                }
                             }
                         }
                 }

--- a/Sources/BG3MacModManager/Views/VersionGeneratorView.swift
+++ b/Sources/BG3MacModManager/Views/VersionGeneratorView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// Tool for converting between BG3's Version64 Int64 format and human-readable version strings.
+struct VersionGeneratorView: View {
+    @State private var versionString: String = "1.0.0.0"
+    @State private var int64String: String = "36028797018963968"
+    @State private var errorText: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Version Generator")
+                    .font(.title2.bold())
+                Spacer()
+            }
+            .padding()
+
+            Divider()
+
+            VStack(spacing: 20) {
+                Spacer()
+
+                GroupBox("Version String to Int64") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Enter a version like \"1.0.0.0\" (major.minor.revision.build)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        HStack {
+                            TextField("Version (e.g. 1.0.0.0)", text: $versionString)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.body.monospaced())
+                                .frame(maxWidth: 250)
+                                .onSubmit { convertFromVersionString() }
+
+                            Button("Convert") {
+                                convertFromVersionString()
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                    }
+                    .padding(4)
+                }
+                .frame(maxWidth: 500)
+
+                Image(systemName: "arrow.up.arrow.down")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+
+                GroupBox("Int64 to Version String") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Enter a raw Int64 value used in meta.lsx / info.json")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        HStack {
+                            TextField("Int64 (e.g. 36028797018963968)", text: $int64String)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.body.monospaced())
+                                .frame(maxWidth: 250)
+                                .onSubmit { convertFromInt64() }
+
+                            Button("Convert") {
+                                convertFromInt64()
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                    }
+                    .padding(4)
+                }
+                .frame(maxWidth: 500)
+
+                if let error = errorText {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                HStack(spacing: 16) {
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(versionString, forType: .string)
+                    } label: {
+                        Label("Copy Version String", systemImage: "doc.on.doc")
+                    }
+                    .help("Copy \(versionString) to clipboard")
+
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(int64String, forType: .string)
+                    } label: {
+                        Label("Copy Int64", systemImage: "doc.on.doc")
+                    }
+                    .help("Copy \(int64String) to clipboard")
+                }
+
+                Spacer()
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Conversion Logic
+
+    private func convertFromVersionString() {
+        errorText = nil
+        guard let version = Version64(versionString: versionString) else {
+            errorText = "Invalid version string. Use format: major.minor.revision.build (e.g. 1.0.0.0)"
+            return
+        }
+        int64String = String(version.rawValue)
+    }
+
+    private func convertFromInt64() {
+        errorText = nil
+        guard let value = Int64(int64String) else {
+            errorText = "Invalid Int64 value. Enter a numeric value."
+            return
+        }
+        let version = Version64(rawValue: value)
+        versionString = version.description
+    }
+}


### PR DESCRIPTION
…erator

Three high-value features where backend logic already existed, requiring primarily UI integration:

- Mod Extraction: Right-click context menu "Extract to Folder..." on any mod with a PAK file. Uses NSOpenPanel for destination, creates subfolder, extracts all PAK contents, and opens result in Finder.

- Duplicate Resolver: Auto-detects mods sharing the same UUID on startup and shows a resolution dialog with file details (size, date, source) and per-file delete buttons. Also accessible via "Resolve..." button in the warning banner for duplicate UUID warnings.

- Version Generator: New "Tools" sidebar item with bidirectional converter between BG3's Version64 Int64 format and human-readable version strings (e.g. "1.0.0.0" <-> 36028797018963968). Includes copy-to-clipboard.

https://claude.ai/code/session_01KghLjywpRTpAbmGMUGsYEk