### PR TITLE
Add Xcode scheme for proper macOS app bundle creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Swift Package Manager
 .build/
 .swiftpm/
+!.swiftpm/xcode/xcshareddata/
 Package.resolved
 
 # Xcode

--- a/.swiftpm/xcode/xcshareddata/xcschemes/BG3MacModManager.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/BG3MacModManager.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Assemble .app Bundle"
+               scriptText = "#!/bin/bash&#10;set -e&#10;&#10;# This script creates a proper .app bundle for the macOS application&#10;# after Swift Package Manager builds the executable.&#10;&#10;echo &quot;🔨 Assembling .app bundle...&quot;&#10;&#10;# Determine build configuration (debug or release)&#10;if [ &quot;${CONFIGURATION}&quot; = &quot;Release&quot; ]; then&#10;    BUILD_CONFIG=&quot;release&quot;&#10;else&#10;    BUILD_CONFIG=&quot;debug&quot;&#10;fi&#10;&#10;# Get the SPM build directory&#10;SPM_BUILD_DIR=&quot;${SRCROOT}/.build/${BUILD_CONFIG}&quot;&#10;EXECUTABLE_NAME=&quot;BG3MacModManager&quot;&#10;EXECUTABLE_PATH=&quot;${SPM_BUILD_DIR}/${EXECUTABLE_NAME}&quot;&#10;&#10;# Check if executable exists&#10;if [ ! -f &quot;${EXECUTABLE_PATH}&quot; ]; then&#10;    echo &quot;❌ Error: Executable not found at ${EXECUTABLE_PATH}&quot;&#10;    exit 1&#10;fi&#10;&#10;echo &quot;📦 Found executable at: ${EXECUTABLE_PATH}&quot;&#10;&#10;# Create .app bundle structure&#10;APP_NAME=&quot;BG3 Mac Mod Manager&quot;&#10;APP_BUNDLE=&quot;${SPM_BUILD_DIR}/${APP_NAME}.app&quot;&#10;&#10;echo &quot;🗑️  Cleaning previous bundle...&quot;&#10;rm -rf &quot;${APP_BUNDLE}&quot;&#10;&#10;echo &quot;📁 Creating bundle structure...&quot;&#10;mkdir -p &quot;${APP_BUNDLE}/Contents/MacOS&quot;&#10;mkdir -p &quot;${APP_BUNDLE}/Contents/Resources&quot;&#10;&#10;# Copy executable&#10;echo &quot;📋 Copying executable...&quot;&#10;cp &quot;${EXECUTABLE_PATH}&quot; &quot;${APP_BUNDLE}/Contents/MacOS/${EXECUTABLE_NAME}&quot;&#10;chmod +x &quot;${APP_BUNDLE}/Contents/MacOS/${EXECUTABLE_NAME}&quot;&#10;&#10;# Copy Info.plist from source (not from resources)&#10;echo &quot;📋 Copying Info.plist...&quot;&#10;INFO_PLIST_SOURCE=&quot;${SRCROOT}/Sources/BG3MacModManager/Info.plist&quot;&#10;if [ ! -f &quot;${INFO_PLIST_SOURCE}&quot; ]; then&#10;    echo &quot;❌ Error: Info.plist not found at ${INFO_PLIST_SOURCE}&quot;&#10;    exit 1&#10;fi&#10;cp &quot;${INFO_PLIST_SOURCE}&quot; &quot;${APP_BUNDLE}/Contents/Info.plist&quot;&#10;&#10;# Create PkgInfo&#10;echo &quot;📋 Creating PkgInfo...&quot;&#10;echo -n &quot;APPL????&quot; &gt; &quot;${APP_BUNDLE}/Contents/PkgInfo&quot;&#10;&#10;# Copy app icon if it exists&#10;if [ -f &quot;${SRCROOT}/AppIcon.icns&quot; ]; then&#10;    echo &quot;🎨 Copying app icon...&quot;&#10;    cp &quot;${SRCROOT}/AppIcon.icns&quot; &quot;${APP_BUNDLE}/Contents/Resources/AppIcon.icns&quot;&#10;elif [ -f &quot;${SRCROOT}/Resources/AppIcon.icns&quot; ]; then&#10;    echo &quot;🎨 Copying app icon...&quot;&#10;    cp &quot;${SRCROOT}/Resources/AppIcon.icns&quot; &quot;${APP_BUNDLE}/Contents/Resources/AppIcon.icns&quot;&#10;else&#10;    echo &quot;ℹ️  Note: No AppIcon.icns found (app will use generic icon)&quot;&#10;fi&#10;&#10;# Ad-hoc code sign for local development&#10;echo &quot;✍️  Ad-hoc signing...&quot;&#10;codesign --force --sign - &quot;${APP_BUNDLE}&quot; 2&gt;&amp;1 || {&#10;    echo &quot;⚠️  Warning: Code signing failed (may not be critical for development)&quot;&#10;}&#10;&#10;echo &quot;✅ App bundle created successfully at:&quot;&#10;echo &quot;   ${APP_BUNDLE}&quot;&#10;echo &quot;&quot;&#10;ls -lh &quot;${APP_BUNDLE}/Contents/MacOS/${EXECUTABLE_NAME}&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "BG3MacModManager"
+                     BuildableName = "BG3MacModManager"
+                     BlueprintName = "BG3MacModManager"
+                     ReferencedContainer = "container:">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BG3MacModManager"
+               BuildableName = "BG3MacModManager"
+               BlueprintName = "BG3MacModManager"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "$(BUILT_PRODUCTS_DIR)/BG3 Mac Mod Manager.app">
+      </PathRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BG3MacModManager"
+            BuildableName = "BG3MacModManager"
+            BlueprintName = "BG3MacModManager"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "$(BUILT_PRODUCTS_DIR)/BG3 Mac Mod Manager.app">
+      </PathRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BG3MacModManager"
+            BuildableName = "BG3MacModManager"
+            BlueprintName = "BG3MacModManager"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -10,10 +10,7 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "BG3MacModManager",
-            path: "Sources/BG3MacModManager",
-            resources: [
-                .copy("Info.plist")
-            ]
+            path: "Sources/BG3MacModManager"
         ),
         .testTarget(
             name: "BG3MacModManagerTests",

--- a/README.md
+++ b/README.md
@@ -50,25 +50,52 @@ Built with Swift and SwiftUI, this tool provides a first-class macOS experience 
 
 ## Building
 
+### Method 1: Xcode (Recommended for Development)
+
+1. Clone the repository:
 ```bash
-# Clone the repository
 git clone https://github.com/ShaiLaric/BG3MacModManager.git
 cd BG3MacModManager
+```
 
-# Build with Swift Package Manager
-swift build
-
-# Run
-swift run BG3MacModManager
-
-# Or open in Xcode
+2. Open in Xcode:
+```bash
 open Package.swift
 ```
 
-For release builds:
+3. Select the **"BG3MacModManager"** scheme from the scheme dropdown
+
+4. Build and run with **⌘R** (or just build with **⌘B**)
+
+Xcode will automatically create a proper `.app` bundle after building. The app will launch with full GUI support and appear in the Dock.
+
+### Method 2: Command Line Build Script (Distribution Builds)
+
+For creating universal binaries (Intel + Apple Silicon) with code signing for distribution:
+
 ```bash
-swift build -c release
+# Ad-hoc signing (for local use)
+./scripts/build-app.sh
+
+# Or sign with Developer ID for public distribution
+./scripts/build-app.sh --sign "Developer ID Application: Your Name (TEAMID)"
 ```
+
+The app bundle will be created at `build/BG3 Mac Mod Manager.app`.
+
+### Method 3: Direct SPM Build (Command-Line Only)
+
+For quick testing without a GUI app bundle:
+
+```bash
+# Build
+swift build
+
+# Run directly (background process, no Dock icon)
+swift run BG3MacModManager
+```
+
+**Note:** Direct `swift run` launches as a background process without appearing in the Dock or creating a proper .app bundle. Use Method 1 or 2 for full GUI experience.
 
 ## File Locations
 


### PR DESCRIPTION
## Summary
This PR adds proper Xcode integration for building BG3 Mac Mod Manager as a native macOS application with a `.app` bundle, improving the development and distribution experience.

## Key Changes

- **Added Xcode scheme** (`.swiftpm/xcode/xcschemes/BG3MacModManager.xcscheme`): Configures the build process with a post-build shell script that automatically assembles a proper macOS `.app` bundle structure, including:
  - Creating the standard `Contents/MacOS` and `Contents/Resources` directories
  - Copying the executable and `Info.plist`
  - Creating the required `PkgInfo` file
  - Handling app icon inclusion
  - Ad-hoc code signing for local development

- **Updated Package.swift**: Removed `Info.plist` from resources since it's now handled directly by the build script from the source directory

- **Updated .gitignore**: Added exception to track the Xcode shared scheme data (`!.swiftpm/xcode/xcshareddata/`)

- **Enhanced README.md**: Documented three build methods:
  1. **Xcode** (recommended for development) - creates proper `.app` bundle with GUI support
  2. **Build script** - for distribution builds with universal binary and code signing support
  3. **Direct SPM** - quick command-line builds without GUI wrapper

## Implementation Details

The build scheme's post-action script handles the complete `.app` bundle assembly, supporting both Debug and Release configurations. It validates the executable exists, creates the proper macOS bundle structure, and performs ad-hoc code signing. The script includes helpful logging and gracefully handles optional components like app icons.

This approach allows developers to use Xcode's standard build and run workflow while ensuring the application launches as a proper macOS app with Dock integration and full GUI capabilities.

https://claude.ai/code/session_01BN7huZosSn9fDF6dsCYSWE