### PR TITLE
Add missing UniformTypeIdentifiers import to BG3MacModManagerApp

### DIFF
--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 
 @main
 struct BG3MacModManagerApp: App {


### PR DESCRIPTION
The new archive file type filters use UTType initializers that require an explicit import of UniformTypeIdentifiers.

https://claude.ai/code/session_01NqCVup3HHZxy35dwFa3rUX