### PR TITLE
Add missing .help() tooltips to all interactive controls

### DIFF
--- a/Sources/BG3MacModManager/Views/BackupManagerView.swift
+++ b/Sources/BG3MacModManager/Views/BackupManagerView.swift
@@ -93,6 +93,7 @@ struct BackupManagerView: View {
                 createBackup()
             }
             .buttonStyle(.borderedProminent)
+            .help("Create a backup of modsettings.lsx")
             Spacer()
         }
     }

--- a/Sources/BG3MacModManager/Views/DuplicateResolverView.swift
+++ b/Sources/BG3MacModManager/Views/DuplicateResolverView.swift
@@ -31,6 +31,7 @@ struct DuplicateResolverView: View {
                     appState.showDuplicateResolver = false
                 }
                 .keyboardShortcut(.defaultAction)
+                .help("Close the duplicate resolver")
             }
         }
         .padding(24)

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -68,6 +68,7 @@ struct ModListView: View {
                 .background(criticalCount > 0 ? Color.red.opacity(0.1) : Color.yellow.opacity(0.1))
             }
             .buttonStyle(.plain)
+            .help("Show or hide validation warnings")
 
             // Expanded warning list
             if warningsExpanded {
@@ -106,6 +107,7 @@ struct ModListView: View {
                             }
                             .font(.caption2)
                             .buttonStyle(.bordered)
+                            .help("Sort mods by dependency order")
                         }
 
                         if warning.category == .duplicateUUID {
@@ -114,6 +116,7 @@ struct ModListView: View {
                             }
                             .font(.caption2)
                             .buttonStyle(.bordered)
+                            .help("Open duplicate mod resolver")
                         }
                     }
                     .padding(.horizontal, 12)

--- a/Sources/BG3MacModManager/Views/ProfileManagerView.swift
+++ b/Sources/BG3MacModManager/Views/ProfileManagerView.swift
@@ -123,6 +123,7 @@ struct ProfileManagerView: View {
                 showingSaveSheet = true
             }
             .buttonStyle(.borderedProminent)
+            .help("Save current mod configuration as a profile")
             Spacer()
         }
     }

--- a/Sources/BG3MacModManager/Views/SettingsView.swift
+++ b/Sources/BG3MacModManager/Views/SettingsView.swift
@@ -42,6 +42,7 @@ struct SettingsView: View {
                     Text("90 days").tag(90)
                     Text("Forever").tag(0)
                 }
+                .help("How long to keep automatic backups before cleanup")
 
                 Button("Clean Old Backups") {
                     guard backupRetentionDays > 0 else { return }

--- a/Sources/BG3MacModManager/Views/VersionGeneratorView.swift
+++ b/Sources/BG3MacModManager/Views/VersionGeneratorView.swift
@@ -32,11 +32,13 @@ struct VersionGeneratorView: View {
                                 .font(.body.monospaced())
                                 .frame(maxWidth: 250)
                                 .onSubmit { convertFromVersionString() }
+                                .help("Enter version in major.minor.revision.build format")
 
                             Button("Convert") {
                                 convertFromVersionString()
                             }
                             .buttonStyle(.borderedProminent)
+                            .help("Convert version string to Int64")
                         }
                     }
                     .padding(4)
@@ -59,11 +61,13 @@ struct VersionGeneratorView: View {
                                 .font(.body.monospaced())
                                 .frame(maxWidth: 250)
                                 .onSubmit { convertFromInt64() }
+                                .help("Enter the raw Int64 value from meta.lsx or info.json")
 
                             Button("Convert") {
                                 convertFromInt64()
                             }
                             .buttonStyle(.borderedProminent)
+                            .help("Convert Int64 to version string")
                         }
                     }
                     .padding(4)


### PR DESCRIPTION
Adds 11 tooltips across 6 view files: ModListView (warnings toggle, Auto-Sort, Resolve), BackupManagerView (Create Backup Now), ProfileManagerView (Save Current Configuration), SettingsView (backup retention picker), DuplicateResolverView (Done), and VersionGeneratorView (both TextFields and Convert buttons).

https://claude.ai/code/session_01NqCVup3HHZxy35dwFa3rUX