### PR TITLE
Add game compatibility features: ModCrashSanityCheck workaround and save file import

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -30,11 +30,20 @@ Parse the `<Conflicts>` node from `meta.lsx` and warn when conflicting mods are 
 - `Views/ModListView.swift` — added "Deactivate" action button for conflict warnings in the banner
 - `Views/ModRowView.swift` — added tooltips for SE badge and no-metadata label
 
-### Phase 3: Game Compatibility (P1)
+### Phase 3: Game Compatibility (P1) [DONE]
 
-- **ModCrashSanityCheck workaround**: auto-delete the problematic directory on launch
-- **Last-exported order recovery**: detect external modsettings.lsx changes and prompt restore
-- **Import from save files**: extract modsettings.lsx from .lsv archives
+- **ModCrashSanityCheck workaround**: auto-delete the problematic directory on launch and before save
+- **Last-exported order recovery**: detect external modsettings.lsx changes via SHA-256 hash and prompt restore from backup
+- **Import from save files**: extract modsettings.lsx from .lsv archives via PakReader
+
+**Modified files:**
+- `Utilities/FileLocations.swift` — added `modCrashSanityCheckFolder`, `lastExportHashFile`, `modCrashSanityCheckExists`
+- `Models/ModWarning.swift` — added `.modCrashSanityCheck` and `.externalModSettingsChange` categories, `.deleteModCrashSanityCheck` and `.restoreModSettings` suggested actions
+- `Services/ModValidationService.swift` — added `checkModCrashSanityCheck()` validation check
+- `App/AppState.swift` — added `deleteModCrashSanityCheckIfNeeded()`, `recordModSettingsHash()`, `checkForExternalModSettingsChange()`, `restoreFromLatestBackup()`, `importFromSaveFile(url:)`, `showExternalChangeAlert` state
+- `App/BG3MacModManagerApp.swift` — added "Import from Save File..." menu item (Cmd+Shift+I) with save file picker
+- `Views/ModListView.swift` — added "Delete Folder" and "Restore Backup" action buttons in warnings banner
+- `Views/ContentView.swift` — added external modsettings.lsx change detection alert dialog
 
 ### Phase 4: Enhanced UX (P2)
 

--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -31,6 +31,11 @@ struct BG3MacModManagerApp: App {
                 }
                 .keyboardShortcut("i", modifiers: .command)
 
+                Button("Import from Save File...") {
+                    importFromSavePanel()
+                }
+                .keyboardShortcut("i", modifiers: [.command, .shift])
+
                 Divider()
 
                 Button("Refresh Mods") {
@@ -77,6 +82,29 @@ struct BG3MacModManagerApp: App {
                 Task {
                     await appState.importMod(from: url)
                 }
+            }
+        }
+    }
+
+    private func importFromSavePanel() {
+        let panel = NSOpenPanel()
+        panel.title = "Import Load Order from Save File"
+        panel.message = "Select a BG3 save file (.lsv) to import its mod load order"
+        panel.allowedContentTypes = [
+            .init(filenameExtension: "lsv")!,
+        ]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        // Default to the saves directory if it exists
+        let savesDir = FileLocations.savegamesFolder
+        if FileManager.default.fileExists(atPath: savesDir.path) {
+            panel.directoryURL = savesDir
+        }
+
+        if panel.runModal() == .OK, let url = panel.urls.first {
+            Task {
+                await appState.importFromSaveFile(url: url)
             }
         }
     }

--- a/Sources/BG3MacModManager/Models/ModWarning.swift
+++ b/Sources/BG3MacModManager/Models/ModWarning.swift
@@ -50,14 +50,16 @@ struct ModWarning: Identifiable, Equatable {
     }
 
     enum Category: String, CaseIterable {
-        case duplicateUUID       = "Duplicate UUID"
-        case missingDependency   = "Missing Dependency"
-        case wrongLoadOrder      = "Wrong Load Order"
-        case circularDependency  = "Circular Dependency"
-        case conflictingMods     = "Mod Conflict"
-        case phantomMod          = "Phantom Mod"
-        case seRequired          = "Script Extender Required"
-        case noMetadata          = "No Metadata"
+        case duplicateUUID          = "Duplicate UUID"
+        case missingDependency      = "Missing Dependency"
+        case wrongLoadOrder         = "Wrong Load Order"
+        case circularDependency     = "Circular Dependency"
+        case conflictingMods        = "Mod Conflict"
+        case phantomMod             = "Phantom Mod"
+        case seRequired             = "Script Extender Required"
+        case noMetadata             = "No Metadata"
+        case modCrashSanityCheck    = "ModCrashSanityCheck"
+        case externalModSettingsChange = "External modsettings.lsx Change"
     }
 
     enum SuggestedAction: Equatable {
@@ -65,5 +67,7 @@ struct ModWarning: Identifiable, Equatable {
         case deactivateMod(uuid: String)
         case installDependency(name: String)
         case installScriptExtender
+        case deleteModCrashSanityCheck
+        case restoreModSettings
     }
 }

--- a/Sources/BG3MacModManager/Services/ModValidationService.swift
+++ b/Sources/BG3MacModManager/Services/ModValidationService.swift
@@ -22,6 +22,7 @@ final class ModValidationService {
         warnings.append(contentsOf: checkPhantomMods(activeMods: activeMods))
         warnings.append(contentsOf: checkScriptExtenderRequirements(activeMods: activeMods, seStatus: seStatus))
         warnings.append(contentsOf: checkNoMetadataMods(activeMods: activeMods, inactiveMods: inactiveMods))
+        warnings.append(contentsOf: checkModCrashSanityCheck())
 
         return warnings.sorted { $0.severity > $1.severity }
     }
@@ -306,5 +307,18 @@ final class ModValidationService {
                 affectedModUUIDs: [mod.uuid]
             )
         }
+    }
+
+    /// Check if the ModCrashSanityCheck directory exists.
+    /// Since Patch 8 this directory causes BG3 to deactivate externally-managed mods.
+    private func checkModCrashSanityCheck() -> [ModWarning] {
+        guard FileLocations.modCrashSanityCheckExists else { return [] }
+        return [ModWarning(
+            severity: .info,
+            category: .modCrashSanityCheck,
+            message: "ModCrashSanityCheck folder detected",
+            detail: "The ModCrashSanityCheck directory exists. Since Patch 8 this can cause the game to deactivate your mods on launch. Delete it to prevent this.",
+            suggestedAction: .deleteModCrashSanityCheck
+        )]
     }
 }

--- a/Sources/BG3MacModManager/Utilities/FileLocations.swift
+++ b/Sources/BG3MacModManager/Utilities/FileLocations.swift
@@ -34,6 +34,12 @@ enum FileLocations {
         publicProfile.appendingPathComponent("Savegames/Story")
     }
 
+    /// `~/Documents/Larian Studios/Baldur's Gate 3/ModCrashSanityCheck/`
+    /// Since Patch 8, this directory causes the game to deactivate externally-managed mods.
+    static var modCrashSanityCheckFolder: URL {
+        larianDocuments.appendingPathComponent("ModCrashSanityCheck")
+    }
+
     // MARK: - Game Installation (Steam)
 
     static var steamApps: URL {
@@ -97,6 +103,11 @@ enum FileLocations {
         appSupportDirectory.appendingPathComponent("Profiles")
     }
 
+    /// Stores a SHA-256 hash of modsettings.lsx as it was last written by this app.
+    static var lastExportHashFile: URL {
+        appSupportDirectory.appendingPathComponent("last_export_hash")
+    }
+
     // MARK: - Helpers
 
     /// Ensures a directory exists, creating it if necessary.
@@ -117,5 +128,10 @@ enum FileLocations {
     /// Returns true if modsettings.lsx exists.
     static var modSettingsExists: Bool {
         FileManager.default.fileExists(atPath: modSettingsFile.path)
+    }
+
+    /// Returns true if the ModCrashSanityCheck directory exists.
+    static var modCrashSanityCheckExists: Bool {
+        FileManager.default.fileExists(atPath: modCrashSanityCheckFolder.path)
     }
 }

--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -59,6 +59,19 @@ struct ContentView: View {
             DuplicateResolverView()
                 .environmentObject(appState)
         }
+        .alert(
+            "External modsettings.lsx Change Detected",
+            isPresented: $appState.showExternalChangeAlert
+        ) {
+            Button("Restore from Backup") {
+                Task { await appState.restoreFromLatestBackup() }
+            }
+            Button("Keep Current", role: .cancel) {
+                appState.showExternalChangeAlert = false
+            }
+        } message: {
+            Text("The modsettings.lsx file has been modified outside this app (possibly by the game). Would you like to restore your last saved load order from backup?")
+        }
         .overlay(alignment: .bottom) {
             statusBar
         }

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -129,6 +129,24 @@ struct ModListView: View {
                             .buttonStyle(.bordered)
                             .help("Deactivate the conflicting mod to resolve this conflict. You can re-activate it later from the inactive list.")
                         }
+
+                        if case .deleteModCrashSanityCheck = warning.suggestedAction {
+                            Button("Delete Folder") {
+                                appState.deleteModCrashSanityCheckIfNeeded()
+                            }
+                            .font(.caption2)
+                            .buttonStyle(.bordered)
+                            .help("Delete the ModCrashSanityCheck directory to prevent the game from deactivating your mods on launch")
+                        }
+
+                        if case .restoreModSettings = warning.suggestedAction {
+                            Button("Restore Backup") {
+                                Task { await appState.restoreFromLatestBackup() }
+                            }
+                            .font(.caption2)
+                            .buttonStyle(.bordered)
+                            .help("Restore modsettings.lsx from the most recent backup to recover your load order")
+                        }
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)


### PR DESCRIPTION
## Summary
Implements Phase 3 game compatibility features to improve mod management reliability and user experience. This includes automatic detection and removal of the problematic ModCrashSanityCheck directory, external modsettings.lsx change detection with backup recovery, and the ability to import mod load orders directly from BG3 save files.

## Key Changes

**ModCrashSanityCheck Workaround**
- Auto-delete the ModCrashSanityCheck directory on app launch and before saving to prevent the game from deactivating externally-managed mods (Patch 8 issue)
- Added validation check that surfaces a warning if the directory exists
- Provides user-facing "Delete Folder" action button in the warnings banner

**Last-Exported Order Recovery**
- Record SHA-256 hash of modsettings.lsx after each successful save
- Detect external changes to modsettings.lsx by comparing current file hash against stored hash
- Prompt user with alert dialog when external changes are detected
- Provide one-click restore from the most recent backup to recover the load order

**Import from Save Files**
- New menu item "Import from Save File..." (Cmd+Shift+I) to extract modsettings.lsx from .lsv archives
- Reconstructs active/inactive mod lists from save file data
- Creates placeholder entries for mods referenced in the save but not found on disk
- Validates and applies the imported load order

**File Structure Updates**
- Added `modCrashSanityCheckFolder`, `lastExportHashFile`, and `modCrashSanityCheckExists` to FileLocations
- Extended ModWarning with new categories (`.modCrashSanityCheck`, `.externalModSettingsChange`) and actions (`.deleteModCrashSanityCheck`, `.restoreModSettings`)
- Added CryptoKit import for SHA-256 hashing

## Implementation Details
- Hash recording occurs after successful modsettings.lsx write to ensure consistency
- External change detection runs during initial app load to catch game-side modifications
- Save file import uses PakReader to extract files from LSPK archives
- ModCrashSanityCheck deletion is non-fatal; failures surface as validation warnings rather than blocking errors
- All new features integrate with existing validation, backup, and error handling systems

https://claude.ai/code/session_017XQTQCNF8ZhQZXASQNnG5C