### PR TITLE
Add drag-and-drop mod import, SE disappearance warning, and heuristics expansion

### DIFF
--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -77,11 +77,9 @@ struct BG3MacModManagerApp: App {
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
 
-        if panel.runModal() == .OK {
-            for url in panel.urls {
-                Task {
-                    await appState.importMod(from: url)
-                }
+        if panel.runModal() == .OK, !panel.urls.isEmpty {
+            Task {
+                await appState.importMods(from: panel.urls)
             }
         }
     }

--- a/Sources/BG3MacModManager/Models/ModWarning.swift
+++ b/Sources/BG3MacModManager/Models/ModWarning.swift
@@ -60,6 +60,7 @@ struct ModWarning: Identifiable, Equatable {
         case noMetadata             = "No Metadata"
         case modCrashSanityCheck    = "ModCrashSanityCheck"
         case externalModSettingsChange = "External modsettings.lsx Change"
+        case seDisappeared             = "Script Extender Disappeared"
     }
 
     enum SuggestedAction: Equatable {
@@ -70,5 +71,6 @@ struct ModWarning: Identifiable, Equatable {
         case installScriptExtender
         case deleteModCrashSanityCheck
         case restoreModSettings
+        case viewSEStatus
     }
 }

--- a/Sources/BG3MacModManager/Services/CategoryInferenceService.swift
+++ b/Sources/BG3MacModManager/Services/CategoryInferenceService.swift
@@ -1,24 +1,19 @@
 import Foundation
 
-/// Infers a ModCategory for mods using a known-mods database, tag heuristics,
-/// and name heuristics. Users can override inferred categories; overrides are
-/// persisted to disk.
+/// Infers a ModCategory for mods using tag heuristics and name heuristics.
+/// Users can override inferred categories; overrides are persisted to disk.
 final class CategoryInferenceService {
 
     // MARK: - Public API
 
     /// Infer a category for a mod. Checks (in order):
     /// 1. User override (persisted)
-    /// 2. Known-mods database (by UUID)
-    /// 3. Tag-based heuristics
-    /// 4. Name-based heuristics
+    /// 2. Tag-based heuristics
+    /// 3. Name-based heuristics
     /// Returns nil if no category can be inferred (mod stays unsorted).
     func inferCategory(for mod: ModInfo) -> ModCategory? {
         if let override = userOverrides[mod.uuid] {
             return override
-        }
-        if let known = Self.knownMods[mod.uuid] {
-            return known
         }
         if let tagBased = inferFromTags(mod.tags) {
             return tagBased
@@ -88,7 +83,8 @@ final class CategoryInferenceService {
 
         // Frameworks
         for tag in lowered {
-            if tag.contains("framework") || tag.contains("library") || tag == "api" {
+            if tag.contains("framework") || tag.contains("library") || tag == "api"
+                || tag == "core" || tag == "mcm" {
                 return .framework
             }
         }
@@ -98,7 +94,10 @@ final class CategoryInferenceService {
             if tag.contains("cosmetic") || tag.contains("visual") || tag.contains("appearance")
                 || tag.contains("hair") || tag.contains("head") || tag.contains("tattoo")
                 || tag.contains("eye") || tag.contains("body") || tag.contains("face")
-                || tag.contains("dye") || tag.contains("texture") {
+                || tag.contains("dye") || tag.contains("texture") || tag.contains("portrait")
+                || tag.contains("skin") || tag.contains("outfit") || tag.contains("clothing")
+                || tag.contains("accessory") || tag.contains("horn") || tag.contains("tail")
+                || tag.contains("wing") || tag.contains("beard") || tag.contains("model") {
                 return .visual
             }
         }
@@ -107,7 +106,12 @@ final class CategoryInferenceService {
         for tag in lowered {
             if tag.contains("class") || tag.contains("subclass") || tag.contains("spell")
                 || tag.contains("feat") || tag.contains("race") || tag.contains("background")
-                || tag.contains("metamagic") || tag.contains("cantrip") {
+                || tag.contains("metamagic") || tag.contains("cantrip") || tag.contains("origin")
+                || tag.contains("companion") || tag.contains("multiclass") || tag.contains("ability")
+                || tag.contains("warlock") || tag.contains("sorcerer") || tag.contains("barbarian")
+                || tag.contains("ranger") || tag.contains("cleric") || tag.contains("paladin")
+                || tag.contains("bard") || tag.contains("wizard") || tag.contains("rogue")
+                || tag.contains("druid") || tag.contains("fighter") || tag.contains("monk") {
                 return .contentExtension
             }
         }
@@ -116,7 +120,11 @@ final class CategoryInferenceService {
         for tag in lowered {
             if tag.contains("gameplay") || tag.contains("fix") || tag.contains("balance")
                 || tag.contains("tweak") || tag.contains("qol") || tag.contains("item")
-                || tag.contains("equipment") || tag.contains("armor") || tag.contains("weapon") {
+                || tag.contains("equipment") || tag.contains("armor") || tag.contains("weapon")
+                || tag.contains("camp") || tag.contains("inventory") || tag.contains("difficulty")
+                || tag.contains("respec") || tag.contains("travel") || tag.contains("merchant")
+                || tag.contains("gold") || tag.contains("rest") || tag.contains("party")
+                || tag.contains("ai") {
                 return .gameplay
             }
         }
@@ -132,12 +140,14 @@ final class CategoryInferenceService {
         // Late loaders — check first (most specific)
         let latePatterns = [
             "compatibility framework", "spell list combiner", "compat patch",
-            "compatibility patch", " cf ", "patches for "
+            "compatibility patch", " cf ", "patches for ",
+            "action resource combiner", "progressions combiner",
+            "container combiner", "list combiner",
         ]
         for pattern in latePatterns {
             if lowered.contains(pattern) { return .lateLoader }
         }
-        // Name ending with " patch" or " fix" when it also references another mod
+        // Name ending with " patch" or " patches" when it references another mod
         if (lowered.hasSuffix(" patch") || lowered.hasSuffix(" patches"))
             && lowered.count > 10 {
             return .lateLoader
@@ -148,17 +158,24 @@ final class CategoryInferenceService {
             "community library", "improvedui", "impui", "5espells",
             "unlock level curve", "mod configuration menu", "mcm",
             "vlad's grimoire", "vladsgrimoire", "script extender",
-            "native mod loader", "mod fixer", "bg3se"
+            "native mod loader", "mod fixer", "bg3se",
+            "volition cabinet", "communitylib", "shared library",
+            "configuration framework", "party limit begone",
         ]
         for pattern in frameworkPatterns {
             if lowered.contains(pattern) { return .framework }
         }
 
-        // Content extensions (classes, subclasses, spells)
+        // Content extensions (classes, subclasses, spells, D&D archetypes)
         let contentPatterns = [
             "subclass", "new class", "extra spell", "featsextra",
             "metamagic extended", "wild magic d100", "expansion",
-            "additional spell", "new race"
+            "additional spell", "new race",
+            "warlock patron", "sorcerer origin", "barbarian path",
+            "ranger archetype", "cleric domain", "paladin oath",
+            "bard college", "wizard school", "rogue archetype",
+            "druid circle", "fighter archetype", "monk way",
+            "feat expansion", "spell expansion",
         ]
         for pattern in contentPatterns {
             if lowered.contains(pattern) { return .contentExtension }
@@ -168,44 +185,25 @@ final class CategoryInferenceService {
         let visualPatterns = [
             "hair", "cosmetic", "appearance", "portrait", "eyes",
             "skin", "tattoo", "body mod", "head mod", "dye",
-            "visual overhaul", "reshade"
+            "visual overhaul", "reshade", "hairstyle", "outfit",
+            "clothing", "custom head", "eye color", "piercing",
+            "makeup", "scar", "horn", "tail",
         ]
         for pattern in visualPatterns {
             if lowered.contains(pattern) { return .visual }
         }
 
+        // Gameplay
+        let gameplayPatterns = [
+            "camp event", "long rest", "fast travel", "better ai",
+            "party size", "party limit", "carry weight", "auto loot",
+            "starting equipment", "respec", "difficulty",
+            "gold", "trader", "merchant",
+        ]
+        for pattern in gameplayPatterns {
+            if lowered.contains(pattern) { return .gameplay }
+        }
+
         return nil
     }
-
-    // MARK: - Known Mods Database
-    //
-    // UUIDs for popular BG3 mods mapped to their canonical load-order tier.
-    // Sourced from the BG3 Modding Community Wiki's general load order guide.
-
-    // Known UUIDs are populated as users encounter popular mods.
-    // The tag-based and name-based heuristics serve as the primary inference
-    // mechanism so the known-mods list does not need to be exhaustive.
-    //
-    // To add a mod: find its UUID in meta.lsx, add it to the appropriate tier below.
-    static let knownMods: [String: ModCategory] = {
-        var db: [String: ModCategory] = [:]
-
-        // ── Tier 1: Frameworks ──────────────────────────────────────────
-        // Mods here are well-known libraries/frameworks that should always load first.
-        // UUIDs verified from Nexus Mods or mod author pages where possible.
-        let frameworks: [String] = [
-            // Mod Configuration Menu (MCM)
-            "755a8a72-407f-4f0d-9a33-274ac0f5b45d",
-        ]
-        for uuid in frameworks { db[uuid] = .framework }
-
-        // ── Tier 5: Late Loaders ────────────────────────────────────────
-        let lateLoaders: [String] = [
-            // Compatibility Framework
-            "67bbb2ec-4900-4aaf-af8d-e2d3fbc47bd8",
-        ]
-        for uuid in lateLoaders { db[uuid] = .lateLoader }
-
-        return db
-    }()
 }

--- a/Sources/BG3MacModManager/Utilities/FileLocations.swift
+++ b/Sources/BG3MacModManager/Utilities/FileLocations.swift
@@ -108,6 +108,11 @@ enum FileLocations {
         appSupportDirectory.appendingPathComponent("last_export_hash")
     }
 
+    /// Persists whether Script Extender was previously detected as deployed.
+    static var seDeployedFlagFile: URL {
+        appSupportDirectory.appendingPathComponent("se_was_deployed.json")
+    }
+
     // MARK: - Helpers
 
     /// Ensures a directory exists, creating it if necessary.

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -219,6 +219,15 @@ struct ModListView: View {
                             .buttonStyle(.bordered)
                             .help("Restore modsettings.lsx from the most recent backup to recover your load order")
                         }
+
+                        if case .viewSEStatus = warning.suggestedAction {
+                            Button("View SE Status") {
+                                appState.navigateToSidebarItem = "scriptExtender"
+                            }
+                            .font(.caption2)
+                            .buttonStyle(.bordered)
+                            .help("Open the Script Extender status page to check installation and re-deploy")
+                        }
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)


### PR DESCRIPTION
## Summary

This PR implements Phase 5 features: window-level drag-and-drop mod installation from Finder, Script Extender disappearance detection with state persistence, and significant expansion of category inference heuristics.

## Key Changes

**Drag-and-Drop Mod Installation**
- Added window-level `.onDrop()` handler in `ContentView` accepting `.pak`, `.zip`, `.tar`, and compressed variants
- Visual drop target overlay with accent-colored border and "Drop to Import Mods" label
- New `importMods(from:)` batch import method in `AppState` that processes multiple files in one operation
- Post-import activation prompt alerts users to activate newly imported mods with "Activate All" or "Keep Inactive" options
- Duplicate detection reports when existing PAK files are replaced during import
- Updated file picker (`BG3MacModManagerApp.importModFromPanel()`) to use batch import code path

**Script Extender Disappearance Warning**
- Added SE deployment state persistence via `se_was_deployed.json` flag file
- New `recordDeployed()`, `wasDeployed()`, and `clearDeployedFlag()` methods in `ScriptExtenderService`
- `refreshSEStatus()` now records when SE is detected as deployed
- New `checkSEDisappeared()` validation check warns if SE was previously deployed but is now missing
- Added `.seDisappeared` warning category and `.viewSEStatus` suggested action
- "View SE Status" button in warning UI navigates to Script Extender sidebar tab via new `navigateToSidebarItem` property
- Prevents false positives for users who never had SE installed

**Category Inference Heuristics Expansion**
- Removed `knownMods` UUID database (2-entry dictionary) in favor of pure heuristic-based inference
- Expanded tag heuristics with ~30 new keywords: D&D class names (warlock, sorcerer, barbarian, etc.), outfit/clothing, camp/inventory, horn/tail/wing, core, mcm
- Expanded name heuristics with ~30 new patterns: D&D subclass archetypes (warlock patron, paladin oath, ranger archetype, etc.), combiner variants (action resource combiner, progressions combiner), gameplay patterns (camp event, fast travel, party size, carry weight, auto loot, merchants)
- Added new gameplay name patterns section previously missing from `inferFromName()`

**Supporting Changes**
- Added `isImporting`, `lastImportedMods`, `showImportActivation`, and `navigateToSidebarItem` published properties to `AppState`
- Updated `importArchive()` to return list of replaced filenames for duplicate reporting
- Added `seWasPreviouslyDeployed` parameter to `validate()` and `validateForSave()` in `ModValidationService`
- Added `seDeployedFlagFile` to `FileLocations`
- Added importing progress indicator in status bar
- Added sidebar navigation handler via `onChange` modifier

## Implementation Details

- Batch import tracks pre-import mod UUIDs to identify newly added mods post-refresh
- Drop handler uses `DispatchGroup` to collect all dropped file URLs before initiating import
- SE disappearance check only triggers if `wasDeployed()` returns true, preventing spurious warnings
- Category inference now relies entirely on tag/name pattern matching without UUID lookups

https://claude.ai/code/session_01REoaTj4pgTCThcBkNiNYfT