### PR TITLE
Fix macOS 13 compatibility: use single-parameter .onChange(of:) API

### DIFF
--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -38,7 +38,7 @@ struct ContentView: View {
             .overlay {
                 dropTargetOverlay
             }
-            .onChange(of: appState.navigateToSidebarItem) { _, target in
+            .onChange(of: appState.navigateToSidebarItem) { target in
                 if let target = target {
                     if target == "scriptExtender" {
                         selectedSidebarItem = .scriptExtender


### PR DESCRIPTION
The two-parameter closure form { _, target in } requires macOS 14.0+, but the project targets macOS 13.0. Switch to the compatible single-parameter form { target in }.

https://claude.ai/code/session_01REoaTj4pgTCThcBkNiNYfT