### PR TITLE
Fix drag & drop: resolve .draggable/.onMove conflict and race condition

### DIFF
--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -267,15 +267,16 @@ struct ContentView: View {
     }()
 
     private func handleFileDrop(_ providers: [NSItemProvider]) {
-        var urls: [URL] = []
         let group = DispatchGroup()
+        let collectQueue = DispatchQueue(label: "bg3mm.drop-url-collector")
+        var urls: [URL] = []
 
         for provider in providers {
             if provider.canLoadObject(ofClass: URL.self) {
                 group.enter()
                 _ = provider.loadObject(ofClass: URL.self) { url, _ in
                     if let url = url {
-                        urls.append(url)
+                        collectQueue.sync { urls.append(url) }
                     }
                     group.leave()
                 }

--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -255,16 +255,14 @@ struct ContentView: View {
 
     // MARK: - Drag-and-Drop from Finder
 
-    private static let acceptedDropTypes: [UTType] = {
-        var types: [UTType] = [.zip]
-        if let pak = UTType(filenameExtension: "pak") { types.append(pak) }
-        if let tar = UTType(filenameExtension: "tar") { types.append(tar) }
-        if let gz = UTType(filenameExtension: "gz") { types.append(gz) }
-        if let tgz = UTType(filenameExtension: "tgz") { types.append(tgz) }
-        if let bz2 = UTType(filenameExtension: "bz2") { types.append(bz2) }
-        if let xz = UTType(filenameExtension: "xz") { types.append(xz) }
-        return types
-    }()
+    /// Supported file extensions for mod import (pak + archive formats).
+    private static let supportedDropExtensions: Set<String> = [
+        "pak", "zip", "tar", "gz", "tgz", "bz2", "xz"
+    ]
+
+    /// Accept `.fileURL` so Finder drops always match regardless of dynamic UTType
+    /// registration. Extension filtering happens in handleFileDrop / importMods.
+    private static let acceptedDropTypes: [UTType] = [.fileURL]
 
     private func handleFileDrop(_ providers: [NSItemProvider]) {
         let group = DispatchGroup()
@@ -284,9 +282,12 @@ struct ContentView: View {
         }
 
         group.notify(queue: .main) {
-            guard !urls.isEmpty else { return }
+            let supported = urls.filter {
+                Self.supportedDropExtensions.contains($0.pathExtension.lowercased())
+            }
+            guard !supported.isEmpty else { return }
             Task {
-                await appState.importMods(from: urls)
+                await appState.importMods(from: supported)
             }
         }
     }

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -6,7 +6,6 @@ struct ModListView: View {
     @State private var searchText = ""
     @State private var warningsExpanded = false
     @State private var activeDropTargeted = false
-    @State private var inactiveDropTargeted = false
 
     var body: some View {
         HSplitView {
@@ -287,7 +286,7 @@ struct ModListView: View {
                 ForEach(filteredActiveMods) { mod in
                     ModRowView(mod: mod, isActive: true)
                         .tag(mod.uuid)
-                        .draggable(mod.uuid)
+                        .moveDisabled(!searchText.isEmpty)
                         .contextMenu {
                             if !mod.isBasicGameModule {
                                 Button("Deactivate") { appState.deactivateMod(mod) }
@@ -388,27 +387,6 @@ struct ModListView: View {
                 }
             }
             .listStyle(.inset(alternatesRowBackgrounds: true))
-            .dropDestination(for: String.self) { uuids, _ in
-                var deactivated = 0
-                for uuid in uuids {
-                    if let mod = appState.activeMods.first(where: { $0.uuid == uuid }),
-                       !mod.isBasicGameModule {
-                        appState.deactivateMod(mod)
-                        deactivated += 1
-                    }
-                }
-                return deactivated > 0
-            } isTargeted: { targeted in
-                inactiveDropTargeted = targeted
-            }
-            .overlay {
-                if inactiveDropTargeted {
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(Color.secondary, lineWidth: 2)
-                        .padding(2)
-                        .allowsHitTesting(false)
-                }
-            }
         }
     }
 


### PR DESCRIPTION
The .draggable(mod.uuid) modifier on active list rows was intercepting
the drag gesture before .onMove could handle intra-list reordering.
The List-level .dropDestination(for: String.self) consumed the String
drag payload (finding no match in inactiveMods) while .onMove never
fired, silently breaking all load order reordering.

- Remove .draggable() from active list rows so .onMove uses the List's
  native reorder mechanism
- Add .moveDisabled(!searchText.isEmpty) to prevent index mismatch when
  .onMove indices from filteredActiveMods don't align with activeMods
- Remove dead .dropDestination from inactive list (active mods were
  never successfully draggable due to the same conflict)
- Fix race condition in handleFileDrop where NSItemProvider callbacks
  mutate a shared urls array from arbitrary threads without sync

https://claude.ai/code/session_01YE5eQAZfcXznjW2YxDGJwz