### PR TITLE
Automate DMG creation in build script

### DIFF
--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -100,5 +100,8 @@ if [ -z "$SIGN_IDENTITY" ]; then
     echo "  xcrun stapler staple \"$APP_BUNDLE\""
 fi
 
-echo "To create a DMG for distribution:"
-echo "  hdiutil create -volname \"${APP_NAME}\" -srcfolder \"$APP_BUNDLE\" -ov -format UDZO \"$BUILD_DIR/${APP_NAME}.dmg\""
+# Create DMG for distribution
+DMG_PATH="$BUILD_DIR/${APP_NAME}.dmg"
+echo "Creating DMG..."
+hdiutil create -volname "${APP_NAME}" -srcfolder "$APP_BUNDLE" -ov -format UDZO "$DMG_PATH"
+echo "DMG created: $DMG_PATH"


### PR DESCRIPTION
## Summary
Changed the build script to automatically create a DMG file for distribution instead of just printing instructions for manual creation.

## Key Changes
- Converted DMG creation from a manual instruction to an automated step in the build process
- Defined `DMG_PATH` variable to store the output DMG file location
- Replaced echo instructions with actual `hdiutil create` command execution
- Added informational output to indicate when DMG creation starts and completes

## Implementation Details
The script now directly executes the DMG creation command with the same parameters that were previously documented as instructions. This streamlines the build workflow by eliminating the need for developers to manually run the DMG creation command after the build completes.

https://claude.ai/code/session_01NeczmEt24L8nPgehqmAwjX