### PR TITLE
Add load order import and Nexus Mods URL tracking

### DIFF
--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -36,6 +36,11 @@ struct BG3MacModManagerApp: App {
                 }
                 .keyboardShortcut("i", modifiers: [.command, .shift])
 
+                Button("Import Load Order...") {
+                    importLoadOrderPanel()
+                }
+                .keyboardShortcut("l", modifiers: [.command, .shift])
+
                 Divider()
 
                 Button("Refresh Mods") {
@@ -103,6 +108,24 @@ struct BG3MacModManagerApp: App {
         if panel.runModal() == .OK, let url = panel.urls.first {
             Task {
                 await appState.importFromSaveFile(url: url)
+            }
+        }
+    }
+
+    private func importLoadOrderPanel() {
+        let panel = NSOpenPanel()
+        panel.title = "Import Load Order"
+        panel.message = "Select a BG3 Mod Manager JSON export or modsettings.lsx file"
+        panel.allowedContentTypes = [
+            .init(filenameExtension: "json")!,
+            .init(filenameExtension: "lsx")!,
+        ]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        if panel.runModal() == .OK, let url = panel.urls.first {
+            Task {
+                await appState.importLoadOrder(from: url)
             }
         }
     }

--- a/Sources/BG3MacModManager/Services/LoadOrderImportService.swift
+++ b/Sources/BG3MacModManager/Services/LoadOrderImportService.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Parses external load order formats (BG3MM JSON, standalone modsettings.lsx)
+/// and produces a normalized list of mod entries for import.
+final class LoadOrderImportService {
+
+    enum ImportFormat {
+        case bg3mm      // JSON from BG3 Mod Manager (Windows)
+        case lsx        // Raw modsettings.lsx file
+    }
+
+    enum ImportError: Error, LocalizedError {
+        case invalidJSON(String)
+        case unknownFormat(String)
+        case emptyModList
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidJSON(let msg): return "Invalid BG3MM JSON: \(msg)"
+            case .unknownFormat(let ext): return "Unrecognized load order format: .\(ext)"
+            case .emptyModList: return "The imported file contains no mods"
+            }
+        }
+    }
+
+    /// A single entry from an imported load order (format-agnostic).
+    struct ImportedModEntry {
+        let uuid: String
+        let name: String
+        let folder: String
+        let version64: Int64
+        let md5: String
+    }
+
+    /// Result of parsing an external load order file.
+    struct ImportResult {
+        let format: ImportFormat
+        let entries: [ImportedModEntry]
+        let sourceName: String
+    }
+
+    private let modSettingsService = ModSettingsService()
+
+    // MARK: - Public API
+
+    /// Detect format and parse a file URL into an ImportResult.
+    func parseFile(at url: URL) throws -> ImportResult {
+        let ext = url.pathExtension.lowercased()
+        if ext == "json" {
+            return try parseBG3MMJSON(at: url)
+        } else if ext == "lsx" {
+            return try parseLSX(at: url)
+        }
+        throw ImportError.unknownFormat(ext)
+    }
+
+    // MARK: - BG3MM JSON Parsing
+
+    private func parseBG3MMJSON(at url: URL) throws -> ImportResult {
+        let data = try Data(contentsOf: url)
+
+        let export: BG3MMExport
+        do {
+            export = try JSONDecoder().decode(BG3MMExport.self, from: data)
+        } catch {
+            throw ImportError.invalidJSON(error.localizedDescription)
+        }
+
+        let entries = export.mods
+            .filter { !Constants.builtInModuleUUIDs.contains($0.UUID.lowercased()) }
+            .map { mod in
+                ImportedModEntry(
+                    uuid: mod.UUID.lowercased(),
+                    name: mod.modName,
+                    folder: mod.folder,
+                    version64: Int64(mod.version) ?? 36028797018963968,
+                    md5: mod.md5
+                )
+            }
+
+        guard !entries.isEmpty else { throw ImportError.emptyModList }
+
+        return ImportResult(
+            format: .bg3mm,
+            entries: entries,
+            sourceName: "BG3 Mod Manager"
+        )
+    }
+
+    // MARK: - LSX Parsing
+
+    private func parseLSX(at url: URL) throws -> ImportResult {
+        let settings = try modSettingsService.read(from: url)
+
+        let entries: [ImportedModEntry] = settings.modOrder.compactMap { uuid in
+            guard !Constants.builtInModuleUUIDs.contains(uuid.lowercased()) else { return nil }
+            let desc = settings.mods[uuid]
+            return ImportedModEntry(
+                uuid: uuid.lowercased(),
+                name: desc?.name ?? uuid,
+                folder: desc?.folder ?? "",
+                version64: Int64(desc?.version64 ?? "") ?? 36028797018963968,
+                md5: desc?.md5 ?? ""
+            )
+        }
+
+        guard !entries.isEmpty else { throw ImportError.emptyModList }
+
+        return ImportResult(
+            format: .lsx,
+            entries: entries,
+            sourceName: "modsettings.lsx"
+        )
+    }
+}
+
+// MARK: - BG3MM JSON Model
+
+private struct BG3MMExport: Codable {
+    let mods: [BG3MMMod]
+}
+
+private struct BG3MMMod: Codable {
+    let modName: String
+    let UUID: String
+    let folder: String
+    let version: String
+    let md5: String
+}

--- a/Sources/BG3MacModManager/Services/NexusURLService.swift
+++ b/Sources/BG3MacModManager/Services/NexusURLService.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Persists per-mod Nexus Mods URLs to a JSON file.
+/// Follows the same persistence pattern as CategoryInferenceService.
+final class NexusURLService {
+
+    // MARK: - Public API
+
+    /// Get the stored Nexus URL for a mod, if any.
+    func url(for modUUID: String) -> String? {
+        urls[modUUID]
+    }
+
+    /// Set or update the Nexus URL for a mod. Pass nil or empty string to clear.
+    func setURL(_ url: String?, for modUUID: String) {
+        if let url = url, !url.isEmpty {
+            urls[modUUID] = url
+        } else {
+            urls.removeValue(forKey: modUUID)
+        }
+        save()
+    }
+
+    /// All stored URLs (for bulk lookup during import).
+    func allURLs() -> [String: String] {
+        urls
+    }
+
+    // MARK: - Persistence
+
+    private var urls: [String: String] = [:]
+
+    private static var storageURL: URL {
+        FileLocations.appSupportDirectory.appendingPathComponent("nexus_urls.json")
+    }
+
+    init() {
+        load()
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: Self.storageURL),
+              let decoded = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return
+        }
+        urls = decoded
+    }
+
+    private func save() {
+        do {
+            try FileLocations.ensureDirectoryExists(FileLocations.appSupportDirectory)
+            let data = try JSONEncoder().encode(urls)
+            try data.write(to: Self.storageURL, options: .atomic)
+        } catch {
+            // Non-fatal: URLs just won't persist
+        }
+    }
+}

--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -85,6 +85,10 @@ struct ContentView: View {
             DuplicateResolverView()
                 .environmentObject(appState)
         }
+        .sheet(isPresented: $appState.showImportSummary) {
+            ImportSummaryView()
+                .environmentObject(appState)
+        }
         .alert(
             "External modsettings.lsx Change Detected",
             isPresented: $appState.showExternalChangeAlert

--- a/Sources/BG3MacModManager/Views/ImportSummaryView.swift
+++ b/Sources/BG3MacModManager/Views/ImportSummaryView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import AppKit
+
+/// Summary dialog shown after importing a load order with missing mods.
+struct ImportSummaryView: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Import Summary")
+                .font(.title2.bold())
+
+            if let summary = appState.importSummaryResult {
+                // Stats row
+                HStack(spacing: 16) {
+                    statBox(label: "In File", value: "\(summary.totalInFile)")
+                    statBox(label: "Matched", value: "\(summary.matchedCount)")
+                    statBox(label: "Missing", value: "\(summary.missingMods.count)")
+                }
+
+                if summary.matchedCount > 0 {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text("\(summary.matchedCount) mod(s) activated in the imported order.")
+                            .font(.body)
+                    }
+                }
+
+                if !summary.missingMods.isEmpty {
+                    Divider()
+
+                    HStack(spacing: 4) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.yellow)
+                        Text("The following mods were not found locally:")
+                            .font(.headline)
+                    }
+
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(summary.missingMods) { mod in
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(mod.name)
+                                            .font(.body.bold())
+                                        Text(mod.uuid)
+                                            .font(.caption.monospaced())
+                                            .foregroundStyle(.secondary)
+                                            .textSelection(.enabled)
+                                    }
+
+                                    Spacer()
+
+                                    if let urlString = mod.nexusURL,
+                                       let url = URL(string: urlString) {
+                                        Button {
+                                            NSWorkspace.shared.open(url)
+                                        } label: {
+                                            Label("Nexus", systemImage: "safari")
+                                        }
+                                        .buttonStyle(.bordered)
+                                        .controlSize(.small)
+                                        .help("Open mod page on Nexus Mods")
+                                    }
+                                }
+                                .padding(.vertical, 4)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 300)
+
+                    HStack {
+                        Spacer()
+                        Button("Copy Missing Mod Names") {
+                            let names = summary.missingMods.map(\.name).joined(separator: "\n")
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(names, forType: .string)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+            }
+
+            Spacer()
+
+            HStack {
+                Spacer()
+                Button("Done") {
+                    appState.showImportSummary = false
+                    appState.importSummaryResult = nil
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 500, minHeight: 300, maxHeight: 600)
+    }
+
+    private func statBox(label: String, value: String) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(.title.bold().monospacedDigit())
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds the ability to import load orders from external sources (BG3 Mod Manager JSON exports and standalone modsettings.lsx files) and introduces per-mod Nexus Mods URL tracking for quick access to mod pages.

## Key Changes

- **Load Order Import Service** (`LoadOrderImportService.swift`)
  - Parses BG3MM JSON exports and modsettings.lsx files
  - Normalizes entries across formats into a common `ImportedModEntry` structure
  - Filters out built-in modules and validates non-empty results
  - Provides detailed error messages for invalid/unsupported formats

- **Import Summary Dialog** (`ImportSummaryView.swift`)
  - Displays import results with statistics (total, matched, missing)
  - Lists missing mods with their UUIDs and optional Nexus Mods links
  - Provides quick actions: open Nexus page in browser, copy missing mod names to clipboard

- **Nexus Mods URL Service** (`NexusURLService.swift`)
  - Persists per-mod Nexus URLs to `nexus_urls.json` in app support directory
  - Follows same pattern as `CategoryInferenceService` for consistency
  - Supports bulk lookup during import to populate missing mod links

- **Mod Detail View Enhancement** (`ModDetailView.swift`)
  - New "Nexus Mods" section for non-basic-game modules
  - Inline URL display with edit/open/remove actions
  - Text field for adding or updating URLs with save/cancel options

- **App State Updates** (`AppState.swift`)
  - New `importLoadOrder()` method that matches imported mods to local library
  - Reorders active/inactive mods based on import file
  - Generates import summary with missing mod details
  - New `setNexusURL()` method for persisting mod URLs

- **Menu Integration** (`BG3MacModManagerApp.swift`)
  - Added "Import Load Order..." menu item (Cmd+Shift+L)
  - File picker supports both .json and .lsx formats
  - Async import with error handling

- **UI Integration** (`ContentView.swift`)
  - Import summary sheet presentation when mods are missing

## Implementation Details

- Built-in modules are automatically filtered during import to avoid duplication
- Missing mods are identified by UUID and can be looked up on Nexus Mods if URLs were previously stored
- Import preserves the order from the source file while maintaining basic game modules at the start
- All validation and warnings are re-run after import to ensure consistency

https://claude.ai/code/session_01UDWrGNVQ1woRFxajGD9HcZ