### PR TITLE
Fix SwiftUI frame call in ImportSummaryView

### DIFF
--- a/Sources/BG3MacModManager/Views/ImportSummaryView.swift
+++ b/Sources/BG3MacModManager/Views/ImportSummaryView.swift
@@ -95,7 +95,7 @@ struct ImportSummaryView: View {
             }
         }
         .padding(20)
-        .frame(width: 500, minHeight: 300, maxHeight: 600)
+        .frame(minWidth: 500, minHeight: 300, maxHeight: 600)
     }
 
     private func statBox(label: String, value: String) -> some View {


### PR DESCRIPTION
Use .frame(minWidth:minHeight:maxHeight:) instead of the invalid .frame(width:minHeight:maxHeight:) overload.

https://claude.ai/code/session_01UDWrGNVQ1woRFxajGD9HcZ