### PR TITLE
Add context menu enhancements: Move to Top/Bottom, Open on Nexus, Cop…

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -240,6 +240,27 @@ game to deactivate externally-managed mods. BG3MM auto-deletes this folder.
 - Comprehensive HelpView with 13 sections covering all app features
 - Added to sidebar navigation and Help menu (Cmd+?)
 
+### 13. Context Menu Enhancements [Phase 6 - DONE]
+
+**Implemented:**
+- **Move to Top / Move to Bottom**: Right-click context menu actions for active mods to quickly
+  reposition them at the start (after the base game module) or end of the load order
+- **Open on Nexus Mods**: Opens the mod's stored Nexus Mods URL if one has been set via the
+  Detail Panel; otherwise performs a Nexus Mods search for the mod by name
+- **Copy Mod Info**: Copies a formatted multi-line summary of the mod (name, author, version,
+  UUID, category, folder, Nexus URL) to the clipboard for sharing or issue reporting
+
+### Phase 6: Context Menu Enhancements (P4) [DONE]
+
+- **Move to Top / Move to Bottom**: Quick reordering actions for active mods via right-click context menu
+- **Open on Nexus Mods**: Opens stored Nexus URL or falls back to Nexus search by mod name
+- **Copy Mod Info**: Copies formatted mod summary (name, author, version, UUID, category, Nexus URL) to clipboard
+
+**Modified files:**
+- `App/AppState.swift` — added `moveModToTop()`, `moveModToBottom()`, `copyModInfo()`, `openNexusPage()` methods
+- `Views/ModListView.swift` — added "Move to Top", "Move to Bottom", "Open on Nexus Mods", "Copy Mod Info" to active and inactive mod context menus
+- `Views/HelpView.swift` — added "Context Menu Actions" subsection to Mod Management help, updated Manual Ordering and Tools sections
+
 ---
 
 ## Future Ideas Backlog

--- a/Sources/BG3MacModManager/Views/HelpView.swift
+++ b/Sources/BG3MacModManager/Views/HelpView.swift
@@ -193,6 +193,20 @@ struct HelpView: View {
                 "File path with Reveal in Finder",
             ])
 
+            helpHeading("Context Menu Actions")
+            helpText("""
+            Right-click any mod to access a context menu with actions specific to that mod. \
+            The available actions depend on whether the mod is active or inactive:
+            """)
+            helpBulletList([
+                "Move to Top / Move to Bottom — Quickly reorder an active mod to the start or end of the load order (after the base game module).",
+                "Open on Nexus Mods — Opens the mod's Nexus Mods page if a URL has been set, or searches Nexus Mods for the mod by name.",
+                "Copy Mod Info — Copies a formatted summary of the mod (name, author, version, UUID, category, and Nexus URL) to the clipboard. Useful for sharing your mod list or reporting issues.",
+                "Copy UUID — Copies just the mod's UUID to the clipboard.",
+                "Extract to Folder... — Extracts the mod's PAK archive contents to a folder of your choice.",
+                "Delete from Disk... — Permanently removes an inactive mod's PAK file (see Deleting Mods section).",
+            ])
+
             helpHeading("Multi-Selection")
             helpText("""
             Hold Cmd and click to select multiple mods, or Shift+Click to select a range. \
@@ -223,7 +237,8 @@ struct HelpView: View {
             helpHeading("Manual Ordering")
             helpText("""
             Drag mods up or down in the Active Mods list to reorder them. The number shown on the \
-            left of each row indicates its position in the load order.
+            left of each row indicates its position in the load order. You can also right-click a mod \
+            and choose \"Move to Top\" or \"Move to Bottom\" for quick repositioning.
             """)
 
             helpHeading("Smart Sort")
@@ -564,6 +579,13 @@ struct HelpView: View {
             helpText("""
             In the Detail Panel's File Info section, click the arrow button next to the file \
             path to reveal the mod's .pak file in Finder.
+            """)
+
+            helpHeading("Copy Mod Info")
+            helpText("""
+            Right-click any mod and choose \"Copy Mod Info\" to copy a formatted summary including \
+            name, author, version, UUID, category, and Nexus URL to the clipboard. This is useful \
+            for sharing your mod setup or filing bug reports.
             """)
 
             helpHeading("Copy UUID / Folder")

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -301,7 +301,30 @@ struct ModListView: View {
                                     }
                                 }
                             }
+
+                            if !mod.isBasicGameModule {
+                                Divider()
+                                Button("Move to Top") {
+                                    appState.moveModToTop(mod)
+                                }
+                                .help("Move this mod to the top of the load order (after the base game module)")
+                                Button("Move to Bottom") {
+                                    appState.moveModToBottom(mod)
+                                }
+                                .help("Move this mod to the end of the load order")
+                            }
+
                             Divider()
+                            Button("Open on Nexus Mods") {
+                                appState.openNexusPage(for: mod)
+                            }
+                            .help(appState.nexusURLService.url(for: mod.uuid) != nil
+                                  ? "Open this mod's Nexus Mods page"
+                                  : "Search for this mod on Nexus Mods")
+                            Button("Copy Mod Info") {
+                                appState.copyModInfo(mod)
+                            }
+                            .help("Copy mod name, author, version, UUID, and other details to the clipboard")
                             Button("Copy UUID") {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(mod.uuid, forType: .string)
@@ -373,6 +396,16 @@ struct ModListView: View {
                                 }
                             }
                             Divider()
+                            Button("Open on Nexus Mods") {
+                                appState.openNexusPage(for: mod)
+                            }
+                            .help(appState.nexusURLService.url(for: mod.uuid) != nil
+                                  ? "Open this mod's Nexus Mods page"
+                                  : "Search for this mod on Nexus Mods")
+                            Button("Copy Mod Info") {
+                                appState.copyModInfo(mod)
+                            }
+                            .help("Copy mod name, author, version, UUID, and other details to the clipboard")
                             Button("Copy UUID") {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(mod.uuid, forType: .string)


### PR DESCRIPTION
…y Mod Info

Implement the Context Menu Enhancements backlog item as Phase 6:

- Move to Top / Move to Bottom: quick reordering for active mods via right-click, placing mods after the base game module or at the end
- Open on Nexus Mods: opens stored Nexus URL if set, otherwise falls back to a Nexus Mods search by mod name
- Copy Mod Info: copies formatted multi-line summary (name, author, version, UUID, category, folder, Nexus URL) to clipboard

Also updates HelpView with Context Menu Actions documentation and PLAN.md to record the completed phase.

https://claude.ai/code/session_01XN5u9qEXg8SdwbJmpwAEJ7