### PR TITLE
Fix release workflow: grant contents write permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: macos-14


### PR DESCRIPTION
The GITHUB_TOKEN needs write access to create releases.

https://claude.ai/code/session_01X8m7zQzqPPVt5HKxBZGKHB