### PR TITLE
Add primary action bar with save, rescan, and launch buttons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+## Project Overview
+
+BG3 Mac Mod Manager is a macOS SwiftUI application for managing Baldur's Gate 3 mods. It uses Swift Package Manager (SPM) with swift-tools-version 5.9, targeting macOS 13+.
+
+## Build Environment
+
+**Do not attempt `swift build`, `swift test`, or any Swift toolchain commands.** The CI/CD environment does not have Swift installed. Verify correctness by reading code and checking that changes follow existing patterns.
+
+## Project Structure
+
+```
+Sources/BG3MacModManager/
+  App/          - App entry point (BG3MacModManagerApp), AppState
+  Models/       - Data models (ModModel, ModCategory, etc.)
+  Services/     - Business logic (ModService, LaunchService, etc.)
+  Utilities/    - Helpers (FileLocations, etc.)
+  Views/        - SwiftUI views (ContentView, ModListView, etc.)
+Tests/BG3MacModManagerTests/
+```
+
+## Key Patterns
+
+- **Icons**: SF Symbols only — no custom image assets
+- **Button styles**: `.borderedProminent` for primary actions, `.bordered` for secondary, `.plain` for icon-only
+- **Toolbar**: Standard macOS toolbar in ContentView; in-content action bars in views like ModListView for prominent buttons
+- **All buttons** should have `.help()` tooltips
+- **State**: Single `AppState` (ObservableObject) passed via `.environmentObject()`
+- **Async**: Use `Task { await ... }` in button actions for async AppState methods
+
+## Dependencies
+
+- [ZIPFoundation](https://github.com/weichsel/ZIPFoundation) (>=0.9.19) — ZIP archive handling

--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -49,6 +49,13 @@ struct BG3MacModManagerApp: App {
                 .keyboardShortcut("r", modifiers: .command)
             }
 
+            CommandGroup(replacing: .saveItem) {
+                Button("Save Load Order") {
+                    Task { await appState.saveModSettings() }
+                }
+                .keyboardShortcut("s", modifiers: .command)
+            }
+
             CommandGroup(replacing: .help) {
                 Button("BG3 Mac Mod Manager Help") {
                     appState.navigateToSidebarItem = "help"

--- a/Sources/BG3MacModManager/Views/HelpView.swift
+++ b/Sources/BG3MacModManager/Views/HelpView.swift
@@ -636,6 +636,7 @@ struct HelpView: View {
             helpTitle("Keyboard Shortcuts")
 
             helpShortcutTable([
+                ("Cmd+S", "Save Load Order"),
                 ("Cmd+I", "Import Mod"),
                 ("Cmd+Shift+I", "Import from Save File"),
                 ("Cmd+Shift+L", "Import Load Order"),

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -11,6 +11,10 @@ struct ModListView: View {
         HSplitView {
             // Left: Active + Inactive mod lists
             VStack(spacing: 0) {
+                // Primary action bar
+                actionBar
+                Divider()
+
                 // Warnings banner
                 if !appState.warnings.isEmpty {
                     warningsBanner
@@ -40,6 +44,47 @@ struct ModListView: View {
                 appState.selectedModID = nil
             }
         }
+    }
+
+    // MARK: - Action Bar
+
+    private var actionBar: some View {
+        HStack(spacing: 12) {
+            Button {
+                Task { await appState.saveModSettings() }
+            } label: {
+                Label("Save Load Order", systemImage: "arrow.down.doc.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+            .disabled(appState.isLoading)
+            .help("Save mod order to modsettings.lsx")
+
+            Button {
+                Task { await appState.refreshAll() }
+            } label: {
+                Label("Rescan Folder", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+            .disabled(appState.isLoading)
+            .help("Rescan mods folder")
+
+            Spacer()
+
+            Button {
+                appState.launchGame()
+            } label: {
+                Label("Launch BG3", systemImage: "play.fill")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+            .disabled(!appState.isGameInstalled)
+            .help("Launch Baldur's Gate 3")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
     }
 
     // MARK: - Multi-Select Action Bar


### PR DESCRIPTION
## Summary
This PR adds a prominent action bar to the top of the mod list view, providing quick access to the most common user actions: saving the load order, rescanning the mods folder, and launching the game.

## Key Changes
- **New Action Bar Component**: Added a primary action bar at the top of ModListView with three main buttons:
  - "Save Load Order" (prominent style) - saves mod settings to modsettings.lsx
  - "Rescan Folder" (bordered style) - rescans the mods folder for changes
  - "Launch BG3" (bordered style) - launches Baldur's Gate 3
  
- **Keyboard Shortcut**: Added Cmd+S keyboard shortcut to save load order via the app menu's save command group

- **Help Documentation**: Updated the keyboard shortcuts table in HelpView to document the new Cmd+S shortcut

## Implementation Details
- The action bar is positioned at the top of the mod list, above the warnings banner
- Buttons are disabled appropriately (save/rescan disabled during loading, launch disabled if game not installed)
- Uses macOS standard button styles (.borderedProminent for primary action, .bordered for secondary)
- Includes helpful tooltips for each button
- The save button is visually emphasized as the primary action

https://claude.ai/code/session_01YKStdWeJjMjpUXRLt3eS4V