### PR TITLE
Add GPL-3.0-or-later SPDX license headers to all source files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,5 @@
 // swift-tools-version: 5.9
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 import PackageDescription
 

--- a/Sources/BG3MacModManager/App/AppState.swift
+++ b/Sources/BG3MacModManager/App/AppState.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 import Combine
 import CryptoKit

--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 import AppKit
 import UniformTypeIdentifiers

--- a/Sources/BG3MacModManager/Models/ModCategory.swift
+++ b/Sources/BG3MacModManager/Models/ModCategory.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// Load order tier for category-aware smart sorting.

--- a/Sources/BG3MacModManager/Models/ModInfo.swift
+++ b/Sources/BG3MacModManager/Models/ModInfo.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 import CryptoKit
 

--- a/Sources/BG3MacModManager/Models/ModProfile.swift
+++ b/Sources/BG3MacModManager/Models/ModProfile.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// A saved mod configuration (load order + active mods).

--- a/Sources/BG3MacModManager/Models/ModWarning.swift
+++ b/Sources/BG3MacModManager/Models/ModWarning.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Represents a detected issue with the mod configuration.

--- a/Sources/BG3MacModManager/Services/ArchiveService.swift
+++ b/Sources/BG3MacModManager/Services/ArchiveService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 import ZIPFoundation
 

--- a/Sources/BG3MacModManager/Services/BackupService.swift
+++ b/Sources/BG3MacModManager/Services/BackupService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 import Darwin
 

--- a/Sources/BG3MacModManager/Services/CategoryInferenceService.swift
+++ b/Sources/BG3MacModManager/Services/CategoryInferenceService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Infers a ModCategory for mods using tag heuristics and name heuristics.

--- a/Sources/BG3MacModManager/Services/GameLaunchService.swift
+++ b/Sources/BG3MacModManager/Services/GameLaunchService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Launches Baldur's Gate 3 via Steam with optional Script Extender support.

--- a/Sources/BG3MacModManager/Services/LoadOrderImportService.swift
+++ b/Sources/BG3MacModManager/Services/LoadOrderImportService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Parses external load order formats (BG3MM JSON, standalone modsettings.lsx)

--- a/Sources/BG3MacModManager/Services/ModDiscoveryService.swift
+++ b/Sources/BG3MacModManager/Services/ModDiscoveryService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Discovers mods by scanning the Mods folder and parsing metadata from

--- a/Sources/BG3MacModManager/Services/ModSettingsService.swift
+++ b/Sources/BG3MacModManager/Services/ModSettingsService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Reads and writes the `modsettings.lsx` file that controls which mods BG3 loads.

--- a/Sources/BG3MacModManager/Services/ModValidationService.swift
+++ b/Sources/BG3MacModManager/Services/ModValidationService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Validates the current mod configuration and produces warnings about potential issues.

--- a/Sources/BG3MacModManager/Services/NexusURLService.swift
+++ b/Sources/BG3MacModManager/Services/NexusURLService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Persists per-mod Nexus Mods URLs to a JSON file.

--- a/Sources/BG3MacModManager/Services/PakReader.swift
+++ b/Sources/BG3MacModManager/Services/PakReader.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 import Compression
 

--- a/Sources/BG3MacModManager/Services/ProfileService.swift
+++ b/Sources/BG3MacModManager/Services/ProfileService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Saves and loads mod profiles (named load order configurations).

--- a/Sources/BG3MacModManager/Services/ScriptExtenderService.swift
+++ b/Sources/BG3MacModManager/Services/ScriptExtenderService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Detects and manages bg3se-macos (Script Extender for macOS) integration.

--- a/Sources/BG3MacModManager/Services/TextExportService.swift
+++ b/Sources/BG3MacModManager/Services/TextExportService.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Exports active mod lists to various text formats (CSV, Markdown, plain text).

--- a/Sources/BG3MacModManager/Utilities/FileLocations.swift
+++ b/Sources/BG3MacModManager/Utilities/FileLocations.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Central registry of all BG3-related file paths on macOS.

--- a/Sources/BG3MacModManager/Utilities/Version64.swift
+++ b/Sources/BG3MacModManager/Utilities/Version64.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Foundation
 
 /// Encodes and decodes BG3's Version64 format.

--- a/Sources/BG3MacModManager/Views/BackupManagerView.swift
+++ b/Sources/BG3MacModManager/Views/BackupManagerView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// View for managing modsettings.lsx backups.

--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 import UniformTypeIdentifiers
 

--- a/Sources/BG3MacModManager/Views/DuplicateResolverView.swift
+++ b/Sources/BG3MacModManager/Views/DuplicateResolverView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// Sheet for resolving duplicate UUID conflicts by choosing which PAK files to keep.

--- a/Sources/BG3MacModManager/Views/HelpView.swift
+++ b/Sources/BG3MacModManager/Views/HelpView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// In-app help documentation covering all features of BG3 Mac Mod Manager.

--- a/Sources/BG3MacModManager/Views/ImportSummaryView.swift
+++ b/Sources/BG3MacModManager/Views/ImportSummaryView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 import AppKit
 

--- a/Sources/BG3MacModManager/Views/ModDetailView.swift
+++ b/Sources/BG3MacModManager/Views/ModDetailView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// Detail panel showing full mod information.

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// Main mod management view with active (load order) and inactive mod lists.

--- a/Sources/BG3MacModManager/Views/ModRowView.swift
+++ b/Sources/BG3MacModManager/Views/ModRowView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// A single row in the mod list showing mod name, author, and status indicators.

--- a/Sources/BG3MacModManager/Views/ProfileManagerView.swift
+++ b/Sources/BG3MacModManager/Views/ProfileManagerView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 import UniformTypeIdentifiers
 

--- a/Sources/BG3MacModManager/Views/SEStatusView.swift
+++ b/Sources/BG3MacModManager/Views/SEStatusView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// View showing Script Extender (bg3se-macos) installation status and controls.

--- a/Sources/BG3MacModManager/Views/SettingsView.swift
+++ b/Sources/BG3MacModManager/Views/SettingsView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// App settings view (shown in Preferences window).

--- a/Sources/BG3MacModManager/Views/VersionGeneratorView.swift
+++ b/Sources/BG3MacModManager/Views/VersionGeneratorView.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import SwiftUI
 
 /// Tool for converting between BG3's Version64 Int64 format and human-readable version strings.

--- a/Tests/BG3MacModManagerTests/Version64Tests.swift
+++ b/Tests/BG3MacModManagerTests/Version64Tests.swift
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import XCTest
 @testable import BG3MacModManager
 


### PR DESCRIPTION
## Summary
This PR adds SPDX license identifiers to all Swift source files and the Package.swift manifest, establishing clear licensing for the BG3 Mac Mod Manager project under the GPL-3.0-or-later license.

## Changes
- Added `// SPDX-License-Identifier: GPL-3.0-or-later` header comment to all Swift source files across:
  - App layer (AppState, BG3MacModManagerApp)
  - Models (ModCategory, ModInfo, ModProfile, ModWarning)
  - Services (ArchiveService, BackupService, CategoryInferenceService, GameLaunchService, LoadOrderImportService, ModDiscoveryService, ModSettingsService, ModValidationService, NexusURLService, PakReader, ProfileService, ScriptExtenderService, TextExportService)
  - Utilities (FileLocations, Version64)
  - Views (BackupManagerView, ContentView, DuplicateResolverView, HelpView, ImportSummaryView, ModDetailView, ModListView, ModRowView, ProfileManagerView, SEStatusView, SettingsView, VersionGeneratorView)
  - Tests (Version64Tests)
- Added SPDX license identifier to Package.swift manifest

## Implementation Details
- License headers follow the standard SPDX format as a single-line comment at the top of each file
- Headers are placed before any import statements with a blank line separator for readability
- Consistent formatting across all 35 source files ensures clear licensing attribution

https://claude.ai/code/session_01BRLBic7VQNdNDciJyZV7rq