### PR TITLE
Fix hdiutil create: remove -format flag incompatible with -size

### DIFF
--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -238,7 +238,7 @@ else
     TEMP_DMG="$BUILD_DIR/temp-${APP_NAME}.dmg"
     rm -f "$TEMP_DMG"
     hdiutil create -size ${DMG_SIZE}m -fs HFS+ -volname "${APP_NAME}" \
-        -format UDRW "$TEMP_DMG" >/dev/null || {
+        "$TEMP_DMG" >/dev/null || {
         echo "Error: Failed to create empty DMG"
         exit 1
     }


### PR DESCRIPTION
The -format UDRW flag requires -srcfolder or -srcdevice and cannot be used with -size. When creating an empty DMG via -size, hdiutil defaults to a read-write format already.

https://claude.ai/code/session_015FBPPTiykEk7YBP6dNuqE2