### PR TITLE
Implement backlog items 1.4, 1.5, 1.7, 2.1, 2.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,17 +48,17 @@ Prioritized feature and UX improvements organized by tier. Each item includes a 
 | 1.1 | Unsaved Changes Indicator | S | **Done** | Track dirty state when load order is mutated; show indicator on Save button. Prevents silently losing work. | `AppState.swift`, `ModListView.swift` |
 | 1.2 | Sidebar Mod Count Badges | S | **Done** | `.badge()` on sidebar items: warning count on Mods, profile count, backup count. | `ContentView.swift` |
 | 1.3 | Keyboard Shortcuts | S | **Done** | Cmd+Shift+E (export ZIP), Cmd+Delete (deactivate selected), Cmd+Shift+G (launch game). Updated HelpView. | `BG3MacModManagerApp.swift`, `HelpView.swift` |
-| 1.4 | Category Filter Chips | S | | Toggleable filter row (Framework/Gameplay/Content/Visual/Late Loader/Uncategorized) above mod lists for users with 100+ mods. | `ModListView.swift` |
-| 1.5 | Mod Description Preview in Row | S | | Show single-line truncated `modDescription` beneath author/version in `ModRowView` for at-a-glance context. | `ModRowView.swift` |
+| 1.4 | Category Filter Chips | S | **Done** | Toggleable filter row (Framework/Gameplay/Content/Visual/Late Loader/Uncategorized) above mod lists. Auto-shown when 20+ mods. Disables reordering when active. | `ModListView.swift` |
+| 1.5 | Mod Description Preview in Row | S | **Done** | Show single-line truncated `modDescription` beneath author/version in `ModRowView` for at-a-glance context. | `ModRowView.swift` |
 | 1.6 | Confirm on Close with Unsaved Changes | S | | Standard macOS "Save changes?" dialog on window close when dirty state is true. Depends on 1.1. | `BG3MacModManagerApp.swift` |
-| 1.7 | Reveal in Finder from Context Menu | S | | Add "Reveal in Finder" to mod row context menus via `NSWorkspace.shared.activateFileViewerSelecting()`. | `ModListView.swift` |
+| 1.7 | Reveal in Finder from Context Menu | S | **Done** | "Reveal in Finder" in both active and inactive mod row context menus via `NSWorkspace.shared.activateFileViewerSelecting()`. | `ModListView.swift` |
 | 1.8 | Persistent Mod Count in Status Bar | S | **Done** | "N active / M inactive" in the bottom status bar as an always-visible summary. | `ContentView.swift` |
 
 ### Tier 2: Medium Features
 
 | # | Title | Scope | Status | Description | Key Files |
 |---|-------|-------|--------|-------------|-----------|
-| 2.1 | Undo/Redo for Load Order | M | | Snapshot `(activeMods, inactiveMods)` before each mutation; support Cmd+Z / Cmd+Shift+Z. | `AppState.swift`, `BG3MacModManagerApp.swift` |
+| 2.1 | Undo/Redo for Load Order | M | **Done** | Snapshot `(activeMods, inactiveMods)` before each mutation; Cmd+Z / Cmd+Shift+Z via Edit menu. 50-level undo stack. | `AppState.swift`, `BG3MacModManagerApp.swift` |
 | 2.2 | Profile Load Missing Mods Report | M | | When loading a profile, show a summary dialog of matched vs. missing mods with Nexus URLs. Reuse `ImportSummaryView`. | `AppState.swift`, `ContentView.swift`, `ImportSummaryView.swift` |
 | 2.3 | Inactive Mods Sorting Options | S–M | | Sort picker for inactive section: by name, author, category, file date, or file size. Currently hardcoded alphabetical. | `ModListView.swift` |
 | 2.4 | PAK Inspector Tool | M | | New tool under "Tools" sidebar to inspect any PAK file's internal listing, meta.lsx, and info.json. Uses existing `PakReader`. | New `PakInspectorView.swift`, `ContentView.swift` |
@@ -67,7 +67,7 @@ Prioritized feature and UX improvements organized by tier. Each item includes a 
 | 2.7 | Profile Renaming and Updating | M | | "Rename" and "Update" (overwrite with current load order) actions on profile rows. | `ProfileManagerView.swift`, `ProfileService.swift`, `AppState.swift` |
 | 2.8 | Auto-save on Launch / Profile Load | S–M | | Settings toggles: "Auto-save before launching game" and "Save on profile load". | `SettingsView.swift`, `AppState.swift` |
 | 2.9 | Warnings Badge Outside Mods Tab | S | **Done** | Critical/warning count badge on "Mods" sidebar item (implemented as part of 1.2). | `ContentView.swift` |
-| 2.10 | Double-Click to Toggle Active/Inactive | S | | Double-click a mod row to activate/deactivate, matching LaughingLeader's BG3MM convention. | `ModRowView.swift` |
+| 2.10 | Double-Click to Toggle Active/Inactive | S | **Done** | Double-click a mod row to activate/deactivate, matching LaughingLeader's BG3MM convention. | `ModListView.swift` |
 
 ### Tier 3: Larger Features
 
@@ -87,9 +87,9 @@ Items marked ~~strikethrough~~ are complete.
 
 1. ~~**1.2 → 1.8 → 2.9** — Instant polish (sidebar badges, status bar count, warning badges)~~
 2. ~~**1.1**~~ **+ 1.6** — ~~Unsaved changes indicator~~ + close confirmation (core UX safety)
-3. **1.7 → 2.10** — Reveal in Finder, double-click toggle (standard conventions)
-4. **1.4 → 1.5** ~~→ **1.3**~~ — Category filters, description preview, ~~keyboard shortcuts~~
-5. **2.1** — Undo/Redo (safety feature, prerequisite for 3.1)
+3. ~~**1.7 → 2.10** — Reveal in Finder, double-click toggle (standard conventions)~~
+4. ~~**1.4 → 1.5**~~ ~~→ **1.3**~~ — ~~Category filters, description preview~~, ~~keyboard shortcuts~~
+5. ~~**2.1** — Undo/Redo (safety feature, prerequisite for 3.1)~~
 6. **2.7 → 2.2** — Profile rename/update, profile load missing mods report
 7. **2.3 → 2.8 → 2.5** — Inactive sorting, auto-save toggles, positional drag
 8. **2.4 → 2.6** — PAK Inspector, advanced filters

--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -66,6 +66,20 @@ struct BG3MacModManagerApp: App {
                 .disabled(appState.activeMods.isEmpty || appState.isExporting)
             }
 
+            CommandGroup(replacing: .undoRedo) {
+                Button("Undo") {
+                    appState.undo()
+                }
+                .keyboardShortcut("z", modifiers: .command)
+                .disabled(!appState.canUndo)
+
+                Button("Redo") {
+                    appState.redo()
+                }
+                .keyboardShortcut("z", modifiers: [.command, .shift])
+                .disabled(!appState.canRedo)
+            }
+
             CommandGroup(after: .toolbar) {
                 Button("Deactivate Selected") {
                     appState.deactivateSelectedMods()

--- a/Sources/BG3MacModManager/Views/HelpView.swift
+++ b/Sources/BG3MacModManager/Views/HelpView.swift
@@ -172,11 +172,20 @@ struct HelpView: View {
 
             helpHeading("Activating & Deactivating")
             helpBulletList([
+                "Double-click a mod row to toggle it between active and inactive",
                 "Right-click a mod and choose Activate or Deactivate",
+                "Click the +/- button on the right side of a mod row",
                 "Drag an inactive mod onto the Active Mods list to activate it",
                 "Use the overflow menu (\"...\") to Activate All or Deactivate All",
                 "Multi-select mods (Cmd+Click or Shift+Click) and use the action bar for bulk operations",
             ])
+
+            helpHeading("Mod Row Information")
+            helpText("""
+            Each mod row shows the mod name, category badge, author, version, and a single-line \
+            description preview (if the mod has a description). Active mods also show their load \
+            order position number on the left.
+            """)
 
             helpHeading("Detail Panel")
             helpText("""
@@ -205,6 +214,7 @@ struct HelpView: View {
                 "Open on Nexus Mods — Opens the mod's Nexus Mods page if a URL has been set, or searches Nexus Mods for the mod by name.",
                 "Copy Mod Info — Copies a formatted summary of the mod (name, author, version, UUID, category, and Nexus URL) to the clipboard. Useful for sharing your mod list or reporting issues.",
                 "Copy UUID — Copies just the mod's UUID to the clipboard.",
+                "Reveal in Finder — Shows the mod's PAK file in Finder.",
                 "Extract to Folder... — Extracts the mod's PAK archive contents to a folder of your choice.",
                 "Delete from Disk... — Permanently removes an inactive mod's PAK file (see Deleting Mods section).",
             ])
@@ -220,6 +230,18 @@ struct HelpView: View {
             helpText("""
             Use the search field at the top to filter mods by name, author, folder, or tags. \
             The filter applies to both active and inactive mod lists simultaneously.
+            """)
+
+            helpHeading("Category Filter Chips")
+            helpText("""
+            A row of category filter chips appears above the mod lists (shown automatically when \
+            you have more than 20 mods). Click a category chip to toggle filtering by that category. \
+            Multiple categories can be selected simultaneously. The \"Uncategorized\" chip controls \
+            whether mods without a category assignment are shown. Click \"Clear\" to reset all filters.
+            """)
+            helpText("""
+            Note: Drag-and-drop reordering is disabled while category filters are active, since \
+            the filtered view does not show all mods.
             """)
         }
     }
@@ -274,6 +296,13 @@ struct HelpView: View {
             From the overflow menu, choose \"Activate Missing Dependencies\" to find all dependencies \
             required by your active mods that are sitting in the inactive list, and activate them \
             automatically. Dependencies are inserted before the mods that need them.
+            """)
+
+            helpHeading("Undo & Redo")
+            helpText("""
+            Every load order change (activating, deactivating, moving, sorting, importing, etc.) \
+            can be undone with Cmd+Z and redone with Cmd+Shift+Z. The undo history stores up to \
+            50 snapshots. Undo/Redo is also available from the Edit menu.
             """)
         }
     }
@@ -579,8 +608,9 @@ struct HelpView: View {
 
             helpHeading("Reveal in Finder")
             helpText("""
-            In the Detail Panel's File Info section, click the arrow button next to the file \
-            path to reveal the mod's .pak file in Finder.
+            Right-click any mod and choose \"Reveal in Finder\" from the context menu to show \
+            the mod's .pak file in Finder. This is also available in the Detail Panel's File Info \
+            section via the arrow button next to the file path.
             """)
 
             helpHeading("Copy Mod Info")
@@ -638,6 +668,8 @@ struct HelpView: View {
             helpTitle("Keyboard Shortcuts")
 
             helpShortcutTable([
+                ("Cmd+Z", "Undo Last Change"),
+                ("Cmd+Shift+Z", "Redo Last Change"),
                 ("Cmd+S", "Save Load Order"),
                 ("Cmd+I", "Import Mod"),
                 ("Cmd+Shift+I", "Import from Save File"),
@@ -650,6 +682,7 @@ struct HelpView: View {
                 ("Cmd+?", "Open Help"),
                 ("Cmd+Click", "Add/remove from multi-selection"),
                 ("Shift+Click", "Extend selection range"),
+                ("Double-Click", "Toggle mod active/inactive"),
             ])
         }
     }

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -8,6 +8,8 @@ struct ModListView: View {
     @State private var searchText = ""
     @State private var warningsExpanded = false
     @State private var activeDropTargeted = false
+    @State private var selectedCategories: Set<ModCategory> = []
+    @State private var showUncategorized = true
 
     var body: some View {
         HSplitView {
@@ -16,6 +18,12 @@ struct ModListView: View {
                 // Primary action bar
                 actionBar
                 Divider()
+
+                // Category filter chips
+                if isCategoryFilterActive || (appState.activeMods.count + appState.inactiveMods.count) > 20 {
+                    categoryFilterBar
+                    Divider()
+                }
 
                 // Warnings banner
                 if !appState.warnings.isEmpty {
@@ -342,7 +350,12 @@ struct ModListView: View {
                 ForEach(filteredActiveMods) { mod in
                     ModRowView(mod: mod, isActive: true)
                         .tag(mod.uuid)
-                        .moveDisabled(!searchText.isEmpty)
+                        .moveDisabled(!searchText.isEmpty || isCategoryFilterActive)
+                        .onTapGesture(count: 2) {
+                            if !mod.isBasicGameModule {
+                                appState.deactivateMod(mod)
+                            }
+                        }
                         .contextMenu {
                             if !mod.isBasicGameModule {
                                 Button("Deactivate") { appState.deactivateMod(mod) }
@@ -385,8 +398,12 @@ struct ModListView: View {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(mod.uuid, forType: .string)
                             }
-                            if mod.pakFilePath != nil {
+                            if let filePath = mod.pakFilePath {
                                 Divider()
+                                Button("Reveal in Finder") {
+                                    NSWorkspace.shared.activateFileViewerSelecting([filePath])
+                                }
+                                .help("Show this mod's PAK file in Finder")
                                 Button("Extract to Folder...") {
                                     appState.extractMod(mod)
                                 }
@@ -439,6 +456,9 @@ struct ModListView: View {
                     ModRowView(mod: mod, isActive: false)
                         .tag(mod.uuid)
                         .draggable(mod.uuid)
+                        .onTapGesture(count: 2) {
+                            appState.activateMod(mod)
+                        }
                         .contextMenu {
                             Button("Activate") { appState.activateMod(mod) }
                             if appState.selectedModIDs.count > 1 {
@@ -466,8 +486,12 @@ struct ModListView: View {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(mod.uuid, forType: .string)
                             }
-                            if mod.pakFilePath != nil {
+                            if let filePath = mod.pakFilePath {
                                 Divider()
+                                Button("Reveal in Finder") {
+                                    NSWorkspace.shared.activateFileViewerSelecting([filePath])
+                                }
+                                .help("Show this mod's PAK file in Finder")
                                 Button("Extract to Folder...") {
                                     appState.extractMod(mod)
                                 }
@@ -561,16 +585,132 @@ struct ModListView: View {
         }
     }
 
+    // MARK: - Category Filter Bar
+
+    /// Whether any category filter is actively narrowing results.
+    private var isCategoryFilterActive: Bool {
+        !selectedCategories.isEmpty || !showUncategorized
+    }
+
+    private var categoryFilterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(ModCategory.allCases, id: \.self) { category in
+                    Button {
+                        if selectedCategories.contains(category) {
+                            selectedCategories.remove(category)
+                        } else {
+                            selectedCategories.insert(category)
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: category.icon)
+                                .font(.caption2)
+                            Text(category.displayName)
+                                .font(.caption)
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            selectedCategories.contains(category)
+                                ? category.color.opacity(0.25)
+                                : Color.clear,
+                            in: Capsule()
+                        )
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(
+                                    selectedCategories.contains(category)
+                                        ? category.color
+                                        : Color.secondary.opacity(0.3),
+                                    lineWidth: 1
+                                )
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .help(category.tooltip)
+                }
+
+                Button {
+                    showUncategorized.toggle()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "questionmark.square")
+                            .font(.caption2)
+                        Text("Uncategorized")
+                            .font(.caption)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        showUncategorized
+                            ? Color.gray.opacity(0.15)
+                            : Color.clear,
+                        in: Capsule()
+                    )
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(
+                                showUncategorized
+                                    ? Color.secondary.opacity(0.5)
+                                    : Color.secondary.opacity(0.3),
+                                lineWidth: 1
+                            )
+                    )
+                }
+                .buttonStyle(.plain)
+                .help("Show or hide mods without a category assignment")
+
+                if isCategoryFilterActive {
+                    Button("Clear") {
+                        selectedCategories.removeAll()
+                        showUncategorized = true
+                    }
+                    .font(.caption)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .help("Reset all category filters")
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+        }
+    }
+
     // MARK: - Filtering
 
     private var filteredActiveMods: [ModInfo] {
-        guard !searchText.isEmpty else { return appState.activeMods }
-        return appState.activeMods.filter { matchesSearch($0) }
+        appState.activeMods.filter { matchesFilters($0) }
     }
 
     private var filteredInactiveMods: [ModInfo] {
-        guard !searchText.isEmpty else { return appState.inactiveMods }
-        return appState.inactiveMods.filter { matchesSearch($0) }
+        appState.inactiveMods.filter { matchesFilters($0) }
+    }
+
+    private func matchesFilters(_ mod: ModInfo) -> Bool {
+        // Always show base game module
+        if mod.isBasicGameModule { return true }
+
+        // Text search filter
+        if !searchText.isEmpty && !matchesSearch(mod) {
+            return false
+        }
+
+        // Category filter (only apply when filter is active)
+        if isCategoryFilterActive {
+            if let category = mod.category {
+                if !selectedCategories.isEmpty && !selectedCategories.contains(category) {
+                    return false
+                }
+            } else {
+                // Uncategorized mod
+                if !showUncategorized {
+                    return false
+                }
+            }
+        }
+
+        return true
     }
 
     private func matchesSearch(_ mod: ModInfo) -> Bool {

--- a/Sources/BG3MacModManager/Views/ModRowView.swift
+++ b/Sources/BG3MacModManager/Views/ModRowView.swift
@@ -65,6 +65,14 @@ struct ModRowView: View {
                             .help("This mod's PAK contains no meta.lsx and no info.json was found. UUID, version, and dependencies are unknown.")
                     }
                 }
+
+                if !mod.modDescription.isEmpty && !mod.isBasicGameModule {
+                    Text(mod.modDescription)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
             }
 
             Spacer()


### PR DESCRIPTION
- 1.4: Category filter chips - toggleable filter row above mod lists with Framework/Gameplay/Content/Visual/Late Loader/Uncategorized chips. Auto-shown when 20+ mods. Disables reordering when active.

- 1.5: Mod description preview - single-line truncated modDescription shown beneath author/version in ModRowView for at-a-glance context.

- 1.7: Reveal in Finder - added to both active and inactive mod row context menus via NSWorkspace.shared.activateFileViewerSelecting().

- 2.1: Undo/Redo for load order - snapshot (activeMods, inactiveMods) before each mutation with 50-level undo stack. Cmd+Z / Cmd+Shift+Z via Edit menu. Covers all mutations: activate, deactivate, move, sort, import, profile load, and dependency activation.

- 2.10: Double-click to toggle - double-click a mod row to activate/deactivate, matching LaughingLeader's BG3MM convention.

Updated HelpView with all new features and keyboard shortcuts. Updated CLAUDE.md backlog statuses.

https://claude.ai/code/session_01HjxbpTPkivFDJmKiU27Vuk