### PR TITLE
Fix NavigationSplitView detail view updates with .id() modifier

### DIFF
--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -196,8 +196,9 @@ struct ContentView: View {
 
     @ViewBuilder
     private var detailView: some View {
-        // ZStack wrapper: Workaround for macOS 13+ NavigationSplitView bug
-        // where conditional detail views fail to update on selection change (Apple Bug 91311311)
+        // ZStack + .id() wrapper: Workaround for macOS 13+ NavigationSplitView bug
+        // where conditional detail views fail to update on selection change (Apple Bug 91311311).
+        // ZStack provides a stable container type; .id() forces view recreation on selection change.
         ZStack {
             switch selectedSidebarItem {
             case .mods:
@@ -214,6 +215,7 @@ struct ContentView: View {
                 HelpView()
             }
         }
+        .id(selectedSidebarItem)
     }
 
     // MARK: - Toolbar


### PR DESCRIPTION
## Summary
Enhanced the workaround for the macOS 13+ NavigationSplitView bug (Apple Bug 91311311) by adding the `.id()` modifier to force view recreation when the selected sidebar item changes.

## Changes
- Added `.id(selectedSidebarItem)` modifier to the detail view ZStack to force view hierarchy recreation on selection changes
- Updated comments to clarify that both ZStack and `.id()` are part of the workaround strategy
- Expanded documentation to explain that ZStack provides a stable container type while `.id()` forces view recreation

## Implementation Details
The `.id()` modifier ensures that when `selectedSidebarItem` changes, SwiftUI treats the entire view hierarchy as a new instance rather than attempting to update the existing one. This works in conjunction with the ZStack wrapper to reliably update conditional detail views in NavigationSplitView, addressing the platform bug where selection changes were not properly reflected in the UI.

https://claude.ai/code/session_0196TGYspkuav7TXFNhpR9U2