### PR TITLE
Remove sidebar badges to fix NavigationSplitView selection bug

### DIFF
--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -172,24 +172,9 @@ struct ContentView: View {
         List(SidebarItem.allCases, selection: $selectedSidebarItem) { item in
             Label(item.rawValue, systemImage: item.icon)
                 .tag(item)
-                .badge(sidebarBadge(for: item))
         }
         .listStyle(.sidebar)
         .frame(minWidth: 180)
-    }
-
-    private func sidebarBadge(for item: SidebarItem) -> Int {
-        switch item {
-        case .mods:
-            // Show critical + warning count so users see issues from any tab
-            return appState.warnings.filter { $0.severity == .critical || $0.severity == .warning }.count
-        case .profiles:
-            return appState.profiles.count
-        case .backups:
-            return appState.backups.count
-        default:
-            return 0
-        }
     }
 
     // MARK: - Detail View


### PR DESCRIPTION
The .badge() modifier on sidebar List items caused the sidebar to re-render whenever appState.warnings/profiles/backups changed. On macOS, NavigationSplitView has a known bug where sidebar re-renders can break the selection → detail view binding, preventing navigation.

This was the only change to the sidebar itself between v1.0.1 (working) and v1.0.2 (broken). Removing the badges restores v1.0.1 sidebar behavior while keeping the other v1.0.2 improvements.

https://claude.ai/code/session_0196TGYspkuav7TXFNhpR9U2