### PR TITLE
Add profile rename and update features with load summary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,12 @@ Prioritized feature and UX improvements organized by tier. Each item includes a 
 | # | Title | Scope | Status | Description | Key Files |
 |---|-------|-------|--------|-------------|-----------|
 | 2.1 | Undo/Redo for Load Order | M | **Done** | Snapshot `(activeMods, inactiveMods)` before each mutation; support Cmd+Z / Cmd+Shift+Z. | `AppState.swift`, `BG3MacModManagerApp.swift` |
-| 2.2 | Profile Load Missing Mods Report | M | | When loading a profile, show a summary dialog of matched vs. missing mods with Nexus URLs. Reuse `ImportSummaryView`. | `AppState.swift`, `ContentView.swift`, `ImportSummaryView.swift` |
+| 2.2 | Profile Load Missing Mods Report | M | **Done** | When loading a profile, show a summary dialog of matched vs. missing mods with Nexus URLs. Reuse `ImportSummaryView`. | `AppState.swift`, `ContentView.swift`, `ImportSummaryView.swift` |
 | 2.3 | Inactive Mods Sorting Options | S–M | | Sort picker for inactive section: by name, author, category, file date, or file size. Currently hardcoded alphabetical. | `ModListView.swift` |
 | 2.4 | PAK Inspector Tool | M | | New tool under "Tools" sidebar to inspect any PAK file's internal listing, meta.lsx, and info.json. Uses existing `PakReader`. | New `PakInspectorView.swift`, `ContentView.swift` |
 | 2.5 | Positional Drag from Inactive to Active | M | | Dragging an inactive mod into the active list should insert at the drop position, not append. | `ModListView.swift`, `AppState.swift` |
 | 2.6 | Advanced Filter Popover | M | | Filter button next to search bar with toggles for: category, SE required, has warnings, metadata source. | `ModListView.swift` |
-| 2.7 | Profile Renaming and Updating | M | | "Rename" and "Update" (overwrite with current load order) actions on profile rows. | `ProfileManagerView.swift`, `ProfileService.swift`, `AppState.swift` |
+| 2.7 | Profile Renaming and Updating | M | **Done** | "Rename" and "Update" (overwrite with current load order) actions on profile rows. | `ProfileManagerView.swift`, `ProfileService.swift`, `AppState.swift` |
 | 2.8 | Auto-save on Launch / Profile Load | S–M | | Settings toggles: "Auto-save before launching game" and "Save on profile load". | `SettingsView.swift`, `AppState.swift` |
 | 2.9 | Warnings Badge Outside Mods Tab | S | **Done** | Critical/warning count badge on "Mods" sidebar item (implemented as part of 1.2). | `ContentView.swift` |
 | 2.10 | Double-Click to Toggle Active/Inactive | S | **Done** | Double-click a mod row to activate/deactivate, matching LaughingLeader's BG3MM convention. | `ModRowView.swift` |
@@ -90,7 +90,7 @@ Items marked ~~strikethrough~~ are complete.
 3. ~~**1.7 → 2.10** — Reveal in Finder, double-click toggle (standard conventions)~~
 4. ~~**1.4 → 1.5**~~ ~~→ **1.3**~~ — ~~Category filters, description preview~~, ~~keyboard shortcuts~~
 5. ~~**2.1** — Undo/Redo (safety feature, prerequisite for 3.1)~~
-6. **2.7 → 2.2** — Profile rename/update, profile load missing mods report
+6. ~~**2.7 → 2.2** — Profile rename/update, profile load missing mods report~~
 7. **2.3 → 2.8 → 2.5** — Inactive sorting, auto-save toggles, positional drag
 8. **2.4 → 2.6** — PAK Inspector, advanced filters
 9. **3.5** — Test suite (pays dividends before larger features)

--- a/Sources/BG3MacModManager/Views/ImportSummaryView.swift
+++ b/Sources/BG3MacModManager/Views/ImportSummaryView.swift
@@ -3,19 +3,23 @@
 import SwiftUI
 import AppKit
 
-/// Summary dialog shown after importing a load order with missing mods.
+/// Summary dialog shown after importing a load order or loading a profile with missing mods.
 struct ImportSummaryView: View {
     @EnvironmentObject var appState: AppState
 
+    private var isProfileLoad: Bool {
+        appState.importSummaryResult?.format.hasPrefix("Profile:") == true
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Import Summary")
+            Text(isProfileLoad ? "Profile Load Summary" : "Import Summary")
                 .font(.title2.bold())
 
             if let summary = appState.importSummaryResult {
                 // Stats row
                 HStack(spacing: 16) {
-                    statBox(label: "In File", value: "\(summary.totalInFile)")
+                    statBox(label: isProfileLoad ? "In Profile" : "In File", value: "\(summary.totalInFile)")
                     statBox(label: "Matched", value: "\(summary.matchedCount)")
                     statBox(label: "Missing", value: "\(summary.missingMods.count)")
                 }
@@ -24,7 +28,9 @@ struct ImportSummaryView: View {
                     HStack(spacing: 4) {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundStyle(.green)
-                        Text("\(summary.matchedCount) mod(s) activated in the imported order.")
+                        Text(isProfileLoad
+                             ? "\(summary.matchedCount) mod(s) matched from your installed mods."
+                             : "\(summary.matchedCount) mod(s) activated in the imported order.")
                             .font(.body)
                     }
                 }

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -455,10 +455,10 @@ struct ModListView: View {
                 ForEach(filteredInactiveMods) { mod in
                     ModRowView(mod: mod, isActive: false)
                         .tag(mod.uuid)
-                        .draggable(mod.uuid)
                         .onTapGesture(count: 2) {
                             appState.activateMod(mod)
                         }
+                        .draggable(mod.uuid)
                         .contextMenu {
                             Button("Activate") { appState.activateMod(mod) }
                             if appState.selectedModIDs.count > 1 {


### PR DESCRIPTION
## Summary
This PR adds the ability to rename and update profiles, along with improved feedback when loading profiles with missing mods. The profile manager now displays a summary dialog showing matched vs. missing mods when loading a profile, similar to the import flow.

## Key Changes

- **Profile Rename**: Added inline rename functionality to ProfileManagerView with a text field, submit handling, and focus management. New `renameProfile()` method in AppState and `rename()` in ProfileService.

- **Profile Update**: Added button to overwrite a profile's mod list with the current load order. Includes confirmation dialog and new `updateProfile()` method in AppState and `update()` in ProfileService.

- **Profile Load Summary**: Enhanced `loadProfile()` in AppState to track missing mods and display an import summary dialog when loading a profile with unmatched mods. Shows matched count, missing count, and Nexus URLs for missing mods.

- **ImportSummaryView Enhancement**: Updated to handle both import and profile load scenarios with conditional messaging ("In File" vs "In Profile", different success messages).

- **UI State Management**: Added new @State variables for rename field, focus state, and update confirmation dialog in ProfileManagerView.

- **Minor Fix**: Reordered `.draggable()` modifier in ModListView to appear after `.onTapGesture()` for consistency.

- **Documentation**: Updated CLAUDE.md to mark feature 2.2 (Profile Load Missing Mods Report) as complete.

## Implementation Details

- Profile rename/update operations delete the old file and write a new one with updated metadata (`updatedAt` timestamp).
- Missing mods are tracked during profile load by comparing profile UUIDs against installed mods and creating placeholder entries with Nexus URLs.
- The import summary reuses existing `LoadOrderImportSummary` struct and `ImportSummaryView` component for consistency.
- Rename field auto-focuses and supports both submit and escape key handling.

https://claude.ai/code/session_01KUkwGapevAinDZKp1EtAfu