### PR TITLE
Add unsaved changes confirmation on app quit and window close

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-BG3 Mac Mod Manager is a macOS SwiftUI application for managing Baldur's Gate 3 mods. It uses Swift Package Manager (SPM) with swift-tools-version 5.9, targeting macOS 13+. Current release: **v1.0.5**.
+BG3 Mac Mod Manager is a macOS SwiftUI application for managing Baldur's Gate 3 mods. It uses Swift Package Manager (SPM) with swift-tools-version 5.9, targeting macOS 13+. Current release: **v1.0.6**.
 
 ## Build Environment
 
@@ -52,7 +52,7 @@ Prioritized feature and UX improvements organized by tier. Each item includes a 
 | 1.3 | Keyboard Shortcuts | S | **Done** | Cmd+Shift+E (export ZIP), Cmd+Delete (deactivate selected), Cmd+Shift+G (launch game). Updated HelpView. | `BG3MacModManagerApp.swift`, `HelpView.swift` |
 | 1.4 | Category Filter Chips | S | **Done** | Toggleable filter row (Framework/Gameplay/Content/Visual/Late Loader/Uncategorized) above mod lists for users with 100+ mods. | `ModListView.swift` |
 | 1.5 | Mod Description Preview in Row | S | **Done** | Show single-line truncated `modDescription` beneath author/version in `ModRowView` for at-a-glance context. | `ModRowView.swift` |
-| 1.6 | Confirm on Close with Unsaved Changes | S | | Standard macOS "Save changes?" dialog on window close when dirty state is true. Depends on 1.1. | `BG3MacModManagerApp.swift` |
+| 1.6 | Confirm on Close with Unsaved Changes | S | **Done** | Standard macOS "Save changes?" dialog on window close when dirty state is true. Depends on 1.1. | `BG3MacModManagerApp.swift` |
 | 1.7 | Reveal in Finder from Context Menu | S | **Done** | Add "Reveal in Finder" to mod row context menus via `NSWorkspace.shared.activateFileViewerSelecting()`. | `ModListView.swift` |
 | 1.8 | Persistent Mod Count in Status Bar | S | **Done** | "N active / M inactive" in the bottom status bar as an always-visible summary. | `ContentView.swift` |
 
@@ -88,7 +88,7 @@ Prioritized feature and UX improvements organized by tier. Each item includes a 
 Items marked ~~strikethrough~~ are complete.
 
 1. ~~**1.2 → 1.8 → 2.9** — Instant polish (sidebar badges, status bar count, warning badges)~~
-2. ~~**1.1**~~ **+ 1.6** — ~~Unsaved changes indicator~~ + close confirmation (core UX safety)
+2. ~~**1.1 + 1.6** — Unsaved changes indicator + close confirmation (core UX safety)~~
 3. ~~**1.7 → 2.10** — Reveal in Finder, double-click toggle (standard conventions)~~
 4. ~~**1.4 → 1.5**~~ ~~→ **1.3**~~ — ~~Category filters, description preview~~, ~~keyboard shortcuts~~
 5. ~~**2.1** — Undo/Redo (safety feature, prerequisite for 3.1)~~

--- a/Sources/BG3MacModManager/Info.plist
+++ b/Sources/BG3MacModManager/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.5</string>
+	<string>1.0.6</string>
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/BG3MacModManager/Views/HelpView.swift
+++ b/Sources/BG3MacModManager/Views/HelpView.swift
@@ -336,6 +336,13 @@ struct HelpView: View {
             can be undone with Cmd+Z and redone with Cmd+Shift+Z. The undo history stores up to \
             50 snapshots. Undo/Redo is also available from the Edit menu.
             """)
+
+            helpHeading("Unsaved Changes Protection")
+            helpText("""
+            If you close the window or quit the app while you have unsaved changes to your load \
+            order, a confirmation dialog appears asking whether to Save, Don't Save, or Cancel. \
+            This prevents accidentally losing your load order changes.
+            """)
         }
     }
 
@@ -735,6 +742,7 @@ struct HelpView: View {
                 ("Cmd+R", "Refresh Mods"),
                 ("Cmd+Delete", "Deactivate Selected Mods"),
                 ("Cmd+Shift+G", "Launch Baldur's Gate 3"),
+                ("Cmd+Q", "Quit (prompts to save if unsaved)"),
                 ("Cmd+,", "Open Settings"),
                 ("Cmd+?", "Open Help"),
                 ("Cmd+Click", "Add/remove from multi-selection"),


### PR DESCRIPTION
## Summary
Implements the standard macOS "Save changes?" dialog when users attempt to quit the app or close the window while there are unsaved changes to the mod load order. This prevents accidental data loss and follows macOS UX conventions.

## Key Changes
- **AppDelegate Implementation**: Created a new `AppDelegate` class that conforms to `NSApplicationDelegate` and `NSWindowDelegate` to intercept quit and window close events
- **Quit Confirmation**: `applicationShouldTerminate(_:)` checks for unsaved changes and prompts the user with three options: Save, Don't Save, or Cancel
- **Window Close Confirmation**: `windowShouldClose(_:)` implements the same logic for window close events
- **Alert Dialog**: Added `showUnsavedChangesAlert()` that displays a native macOS warning alert with keyboard shortcuts (Cmd+D for "Don't Save")
- **App State Integration**: The app delegate receives a reference to `AppState` on app launch to check the `hasUnsavedChanges` flag and trigger saves via `performSave()`
- **Help Documentation**: Updated HelpView with a new "Unsaved Changes Protection" section and added Cmd+Q to the keyboard shortcuts reference
- **Version Bump**: Updated to v1.0.6 and marked feature 1.6 as complete in CLAUDE.md

## Implementation Details
- Uses `@NSApplicationDelegateAdaptor` to integrate the custom AppDelegate with SwiftUI
- Handles async save operations with `Task { @MainActor in }` to ensure proper threading
- Returns `.terminateLater` during saves to allow the async operation to complete before termination
- Window delegate is set in `applicationDidFinishLaunching(_:)` to ensure the main window is available
- Alert buttons are configured with proper key equivalents for standard macOS behavior

https://claude.ai/code/session_01N1rfHZGH2kPTrAcWSUHF5L