### PR TITLE
Add comprehensive test suite for core services and models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,16 @@ Sources/BG3MacModManager/
   Utilities/    - Helpers (FileLocations, etc.)
   Views/        - SwiftUI views (ContentView, ModListView, etc.)
 Tests/BG3MacModManagerTests/
+  TestHelpers.swift            - Factory functions (makeModInfo, makeDependency, makeSEStatus)
+  Version64Tests.swift         - Version64 model tests
+  ModInfoTests.swift           - ModInfo model, factories, MetadataSource, Constants
+  DataBinaryReadingTests.swift - Data extension binary reading (UInt16/32/64, Int64)
+  ModCategoryTests.swift       - ModCategory enum ordering, Codable, CaseIterable
+  TextExportServiceTests.swift - CSV/Markdown/plain text export
+  CategoryInferenceServiceTests.swift - Tag/name heuristics, overrides
+  ModValidationServiceTests.swift     - All 10 validation checks, topological sort
+  LoadOrderImportServiceTests.swift   - BG3MM JSON & LSX import parsing
+  PakReaderTests.swift                - Binary format errors, CompressionType
 ```
 
 ## Key Patterns
@@ -73,15 +83,15 @@ Prioritized feature and UX improvements organized by tier. Each item includes a 
 
 ### Tier 3: Larger Features
 
-| # | Title | Scope | Description | Key Files |
-|---|-------|-------|-------------|-----------|
-| 3.1 | Operation History Panel | L | Named undo stack with a History sidebar item ("Activated Mod X", "Smart Sorted", "Loaded Profile Y"). | `AppState.swift`, new `HistoryView.swift`, `ContentView.swift` |
-| 3.2 | Nexus Mods Update Detection | L | Query Nexus API to compare installed vs. latest versions; show "Update Available" badges. Requires API key in Settings. | New `NexusAPIService.swift`, `SettingsView.swift`, `ModRowView.swift` |
-| 3.3 | Mod Groups / Collections | L | User-defined named groups orthogonal to categories. Activate/deactivate/view entire groups. | New `ModGroup.swift`, new `ModGroupService.swift`, multiple views |
-| 3.4 | Conflict Resolution Advisor | L | Analyze conflict graph and suggest compatibility patches, load order adjustments, and Nexus search links. | New `ConflictAdvisorService.swift`, `ModListView.swift`, `ModDetailView.swift` |
-| 3.5 | Comprehensive Test Suite | L | Tests for `ModValidationService`, `CategoryInferenceService`, `LoadOrderImportService`, `TextExportService`, `ModInfo`, `PakReader`. | Multiple new test files in `Tests/` |
-| 3.6 | Per-Mod User Notes | M–L | Editable notes per mod stored in app support JSON, editable from detail panel, icon indicator in row. | New `ModNotesService.swift`, `ModDetailView.swift`, `ModRowView.swift` |
-| 3.7 | Bulk Nexus URL Import | M–L | Import Vortex/MO2 export files to bulk-populate Nexus URLs for matching mods. | New `NexusURLImportView.swift`, `NexusURLService.swift`, `ContentView.swift` |
+| # | Title | Scope | Status | Description | Key Files |
+|---|-------|-------|--------|-------------|-----------|
+| 3.1 | Operation History Panel | L | | Named undo stack with a History sidebar item ("Activated Mod X", "Smart Sorted", "Loaded Profile Y"). | `AppState.swift`, new `HistoryView.swift`, `ContentView.swift` |
+| 3.2 | Nexus Mods Update Detection | L | | Query Nexus API to compare installed vs. latest versions; show "Update Available" badges. Requires API key in Settings. | New `NexusAPIService.swift`, `SettingsView.swift`, `ModRowView.swift` |
+| 3.3 | Mod Groups / Collections | L | | User-defined named groups orthogonal to categories. Activate/deactivate/view entire groups. | New `ModGroup.swift`, new `ModGroupService.swift`, multiple views |
+| 3.4 | Conflict Resolution Advisor | L | | Analyze conflict graph and suggest compatibility patches, load order adjustments, and Nexus search links. | New `ConflictAdvisorService.swift`, `ModListView.swift`, `ModDetailView.swift` |
+| 3.5 | Comprehensive Test Suite | L | **Done** | ~120 tests across 8 test files + 1 helper: `ModInfoTests`, `DataBinaryReadingTests`, `ModCategoryTests`, `TextExportServiceTests`, `CategoryInferenceServiceTests`, `ModValidationServiceTests`, `LoadOrderImportServiceTests`, `PakReaderTests`. | `TestHelpers.swift`, multiple test files in `Tests/` |
+| 3.6 | Per-Mod User Notes | M–L | | Editable notes per mod stored in app support JSON, editable from detail panel, icon indicator in row. | New `ModNotesService.swift`, `ModDetailView.swift`, `ModRowView.swift` |
+| 3.7 | Bulk Nexus URL Import | M–L | | Import Vortex/MO2 export files to bulk-populate Nexus URLs for matching mods. | New `NexusURLImportView.swift`, `NexusURLService.swift`, `ContentView.swift` |
 
 ### Recommended Implementation Order
 
@@ -95,6 +105,6 @@ Items marked ~~strikethrough~~ are complete.
 6. ~~**2.7 → 2.2** — Profile rename/update, profile load missing mods report~~
 7. ~~**2.3 → 2.8 → 2.5** — Inactive sorting, auto-save toggles, positional drag~~
 8. ~~**2.4 → 2.6** — PAK Inspector, advanced filters~~
-9. **3.5** — Test suite (pays dividends before larger features)
+9. ~~**3.5** — Test suite (pays dividends before larger features)~~
 10. **3.6 → 3.7 → 3.2** — Per-mod notes, bulk Nexus import, update detection
 11. **3.3 → 3.1 → 3.4** — Mod groups, history panel, conflict advisor

--- a/Tests/BG3MacModManagerTests/CategoryInferenceServiceTests.swift
+++ b/Tests/BG3MacModManagerTests/CategoryInferenceServiceTests.swift
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class CategoryInferenceServiceTests: XCTestCase {
+
+    var service: CategoryInferenceService!
+
+    override func setUp() {
+        super.setUp()
+        // init() attempts to load overrides from disk; fails silently, starting with empty overrides.
+        service = CategoryInferenceService()
+    }
+
+    // MARK: - Tag Heuristics: Late Loader
+
+    func testTagCompatibilityInfersLateLoader() {
+        let mod = makeModInfo(tags: ["compatibility"])
+        XCTAssertEqual(service.inferCategory(for: mod), .lateLoader)
+    }
+
+    func testTagPatchInfersLateLoader() {
+        let mod = makeModInfo(tags: ["patch"])
+        XCTAssertEqual(service.inferCategory(for: mod), .lateLoader)
+    }
+
+    func testTagCombinerInfersLateLoader() {
+        let mod = makeModInfo(tags: ["combiner"])
+        XCTAssertEqual(service.inferCategory(for: mod), .lateLoader)
+    }
+
+    // MARK: - Tag Heuristics: Framework
+
+    func testTagFrameworkInfersFramework() {
+        let mod = makeModInfo(tags: ["framework"])
+        XCTAssertEqual(service.inferCategory(for: mod), .framework)
+    }
+
+    func testTagLibraryInfersFramework() {
+        let mod = makeModInfo(tags: ["library"])
+        XCTAssertEqual(service.inferCategory(for: mod), .framework)
+    }
+
+    func testTagAPIInfersFramework() {
+        let mod = makeModInfo(tags: ["api"])
+        XCTAssertEqual(service.inferCategory(for: mod), .framework)
+    }
+
+    func testTagMCMInfersFramework() {
+        let mod = makeModInfo(tags: ["mcm"])
+        XCTAssertEqual(service.inferCategory(for: mod), .framework)
+    }
+
+    // MARK: - Tag Heuristics: Visual
+
+    func testTagCosmeticInfersVisual() {
+        let mod = makeModInfo(tags: ["cosmetic"])
+        XCTAssertEqual(service.inferCategory(for: mod), .visual)
+    }
+
+    func testTagHairInfersVisual() {
+        let mod = makeModInfo(tags: ["hair"])
+        XCTAssertEqual(service.inferCategory(for: mod), .visual)
+    }
+
+    func testTagTextureInfersVisual() {
+        let mod = makeModInfo(tags: ["texture"])
+        XCTAssertEqual(service.inferCategory(for: mod), .visual)
+    }
+
+    // MARK: - Tag Heuristics: Content Extension
+
+    func testTagClassInfersContentExtension() {
+        let mod = makeModInfo(tags: ["class"])
+        XCTAssertEqual(service.inferCategory(for: mod), .contentExtension)
+    }
+
+    func testTagSpellInfersContentExtension() {
+        let mod = makeModInfo(tags: ["spell"])
+        XCTAssertEqual(service.inferCategory(for: mod), .contentExtension)
+    }
+
+    func testTagFeatInfersContentExtension() {
+        let mod = makeModInfo(tags: ["feat"])
+        XCTAssertEqual(service.inferCategory(for: mod), .contentExtension)
+    }
+
+    // MARK: - Tag Heuristics: Gameplay
+
+    func testTagGameplayInfersGameplay() {
+        let mod = makeModInfo(tags: ["gameplay"])
+        XCTAssertEqual(service.inferCategory(for: mod), .gameplay)
+    }
+
+    func testTagFixInfersGameplay() {
+        let mod = makeModInfo(tags: ["fix"])
+        XCTAssertEqual(service.inferCategory(for: mod), .gameplay)
+    }
+
+    func testTagQoLInfersGameplay() {
+        let mod = makeModInfo(tags: ["qol"])
+        XCTAssertEqual(service.inferCategory(for: mod), .gameplay)
+    }
+
+    // MARK: - Tag Heuristics: No Match
+
+    func testUnrelatedTagReturnsNil() {
+        let mod = makeModInfo(tags: ["random_tag"])
+        XCTAssertNil(service.inferCategory(for: mod))
+    }
+
+    func testEmptyTagsReturnsNil() {
+        let mod = makeModInfo(name: "UnknownMod", tags: [])
+        XCTAssertNil(service.inferCategory(for: mod))
+    }
+
+    // MARK: - Tag Priority: Late Loader Checked First
+
+    func testLateLoaderTagTakesPriorityOverFramework() {
+        // "compatibility" is a late loader signal, even alongside "framework"
+        let mod = makeModInfo(tags: ["compatibility", "framework"])
+        XCTAssertEqual(service.inferCategory(for: mod), .lateLoader)
+    }
+
+    // MARK: - Name Heuristics
+
+    func testNameCommunityLibraryInfersFramework() {
+        let mod = makeModInfo(name: "Community Library", tags: [])
+        XCTAssertEqual(service.inferCategory(for: mod), .framework)
+    }
+
+    func testNameSpellListCombinerInfersLateLoader() {
+        let mod = makeModInfo(name: "Spell List Combiner", tags: [])
+        XCTAssertEqual(service.inferCategory(for: mod), .lateLoader)
+    }
+
+    func testNameCustomHairPackInfersVisual() {
+        let mod = makeModInfo(name: "Custom Hair Pack", tags: [])
+        XCTAssertEqual(service.inferCategory(for: mod), .visual)
+    }
+
+    func testNameNewSubclassInfersContentExtension() {
+        let mod = makeModInfo(name: "Paladin Oath Subclass", tags: [])
+        XCTAssertEqual(service.inferCategory(for: mod), .contentExtension)
+    }
+
+    func testNameAutoLootInfersGameplay() {
+        let mod = makeModInfo(name: "Auto Loot Everything", tags: [])
+        XCTAssertEqual(service.inferCategory(for: mod), .gameplay)
+    }
+
+    func testNamePatchSuffixInfersLateLoader() {
+        // Name ending in " patch" with length > 10
+        let mod = makeModInfo(name: "Some Other Mod Patch", tags: [])
+        XCTAssertEqual(service.inferCategory(for: mod), .lateLoader)
+    }
+
+    // MARK: - Tag Takes Priority Over Name
+
+    func testTagTakesPriorityOverName() {
+        // Name sounds visual, but tag says framework
+        let mod = makeModInfo(name: "Custom Hair Framework Override", tags: ["framework"])
+        XCTAssertEqual(service.inferCategory(for: mod), .framework)
+    }
+
+    // MARK: - Override Behavior
+
+    func testOverrideTakesPriority() {
+        let uuid = "override-test-uuid"
+        let mod = makeModInfo(uuid: uuid, tags: ["framework"])
+
+        // Without override, tag-based inference
+        XCTAssertEqual(service.inferCategory(for: mod), .framework)
+
+        // Set override
+        service.setOverride(.lateLoader, for: uuid)
+        XCTAssertEqual(service.inferCategory(for: mod), .lateLoader)
+    }
+
+    func testClearOverride() {
+        let uuid = "clear-test-uuid"
+        let mod = makeModInfo(uuid: uuid, tags: ["gameplay"])
+
+        service.setOverride(.visual, for: uuid)
+        XCTAssertEqual(service.inferCategory(for: mod), .visual)
+
+        // Clear override - should fall back to tag inference
+        service.setOverride(nil, for: uuid)
+        XCTAssertEqual(service.inferCategory(for: mod), .gameplay)
+    }
+
+    func testOverrideReturnsCorrectValue() {
+        let uuid = "query-test-uuid"
+        XCTAssertNil(service.override(for: uuid))
+
+        service.setOverride(.contentExtension, for: uuid)
+        XCTAssertEqual(service.override(for: uuid), .contentExtension)
+    }
+}

--- a/Tests/BG3MacModManagerTests/DataBinaryReadingTests.swift
+++ b/Tests/BG3MacModManagerTests/DataBinaryReadingTests.swift
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class DataBinaryReadingTests: XCTestCase {
+
+    // MARK: - readUInt16
+
+    func testReadUInt16LittleEndian() {
+        let data = Data([0x01, 0x00])
+        XCTAssertEqual(data.readUInt16(at: 0), 1)
+    }
+
+    func testReadUInt16AtOffset() {
+        let data = Data([0xFF, 0xFF, 0x34, 0x12])
+        XCTAssertEqual(data.readUInt16(at: 2), 0x1234)
+    }
+
+    func testReadUInt16OutOfBounds() {
+        let data = Data([0x01])
+        XCTAssertEqual(data.readUInt16(at: 0), 0)
+    }
+
+    // MARK: - readUInt32
+
+    func testReadUInt32LittleEndian() {
+        let data = Data([0x01, 0x00, 0x00, 0x00])
+        XCTAssertEqual(data.readUInt32(at: 0), 1)
+    }
+
+    func testReadUInt32KnownValue() {
+        // 1234 = 0x000004D2, little-endian: D2 04 00 00
+        let data = Data([0xD2, 0x04, 0x00, 0x00])
+        XCTAssertEqual(data.readUInt32(at: 0), 1234)
+    }
+
+    func testReadUInt32OutOfBounds() {
+        let data = Data([0x01, 0x02])
+        XCTAssertEqual(data.readUInt32(at: 0), 0)
+    }
+
+    // MARK: - readUInt64
+
+    func testReadUInt64LittleEndian() {
+        let data = Data([0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        XCTAssertEqual(data.readUInt64(at: 0), 1)
+    }
+
+    func testReadUInt64KnownValue() {
+        // 36028797018963968 = 0x0080000000000000
+        // little-endian: 00 00 00 00 00 00 80 00
+        let data = Data([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00])
+        XCTAssertEqual(data.readUInt64(at: 0), 36028797018963968)
+    }
+
+    func testReadUInt64OutOfBounds() {
+        let data = Data([0x01, 0x02, 0x03])
+        XCTAssertEqual(data.readUInt64(at: 0), 0)
+    }
+
+    // MARK: - readInt64
+
+    func testReadInt64LittleEndian() {
+        let data = Data([0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        XCTAssertEqual(data.readInt64(at: 0), 1)
+    }
+
+    func testReadInt64NegativeValue() {
+        // -1 in two's complement = 0xFFFFFFFFFFFFFFFF
+        let data = Data([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
+        XCTAssertEqual(data.readInt64(at: 0), -1)
+    }
+
+    func testReadInt64OutOfBounds() {
+        let data = Data()
+        XCTAssertEqual(data.readInt64(at: 0), 0)
+    }
+}

--- a/Tests/BG3MacModManagerTests/LoadOrderImportServiceTests.swift
+++ b/Tests/BG3MacModManagerTests/LoadOrderImportServiceTests.swift
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class LoadOrderImportServiceTests: XCTestCase {
+
+    var service: LoadOrderImportService!
+    var tempFiles: [URL] = []
+
+    override func setUp() {
+        super.setUp()
+        service = LoadOrderImportService()
+    }
+
+    override func tearDown() {
+        for url in tempFiles {
+            try? FileManager.default.removeItem(at: url)
+        }
+        tempFiles.removeAll()
+        super.tearDown()
+    }
+
+    /// Write a temporary file and track it for cleanup.
+    private func writeTempFile(name: String, content: String) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bg3test_\(UUID().uuidString)_\(name)")
+        try! content.write(to: url, atomically: true, encoding: .utf8)
+        tempFiles.append(url)
+        return url
+    }
+
+    // MARK: - BG3MM JSON Parsing
+
+    private let sampleJSON = """
+    {
+        "mods": [
+            {
+                "modName": "Test Mod",
+                "UUID": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+                "folder": "TestMod",
+                "version": "36028797018963968",
+                "md5": "abc123"
+            },
+            {
+                "modName": "Another Mod",
+                "UUID": "11111111-2222-3333-4444-555555555555",
+                "folder": "AnotherMod",
+                "version": "36028797018963968",
+                "md5": "def456"
+            }
+        ]
+    }
+    """
+
+    func testParseBG3MMJSON() throws {
+        let url = writeTempFile(name: "loadorder.json", content: sampleJSON)
+        let result = try service.parseFile(at: url)
+
+        XCTAssertEqual(result.format, .bg3mm)
+        XCTAssertEqual(result.entries.count, 2)
+        XCTAssertEqual(result.sourceName, "BG3 Mod Manager")
+    }
+
+    func testParseBG3MMJSONLowercasesUUIDs() throws {
+        let url = writeTempFile(name: "loadorder.json", content: sampleJSON)
+        let result = try service.parseFile(at: url)
+
+        for entry in result.entries {
+            XCTAssertEqual(entry.uuid, entry.uuid.lowercased(),
+                           "UUID should be lowercased: \(entry.uuid)")
+        }
+    }
+
+    func testParseBG3MMJSONFiltersBuiltInUUIDs() throws {
+        let builtInUUID = Constants.baseModuleUUID
+        let json = """
+        {
+            "mods": [
+                {
+                    "modName": "GustavX",
+                    "UUID": "\(builtInUUID)",
+                    "folder": "GustavX",
+                    "version": "36028797018963968",
+                    "md5": ""
+                },
+                {
+                    "modName": "Real Mod",
+                    "UUID": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    "folder": "RealMod",
+                    "version": "36028797018963968",
+                    "md5": "abc"
+                }
+            ]
+        }
+        """
+        let url = writeTempFile(name: "loadorder.json", content: json)
+        let result = try service.parseFile(at: url)
+
+        XCTAssertEqual(result.entries.count, 1)
+        XCTAssertEqual(result.entries.first?.name, "Real Mod")
+    }
+
+    func testParseEmptyModListThrows() {
+        // All mods are built-in, so after filtering the list is empty
+        let builtInUUID = Constants.baseModuleUUID
+        let json = """
+        {
+            "mods": [
+                {
+                    "modName": "GustavX",
+                    "UUID": "\(builtInUUID)",
+                    "folder": "GustavX",
+                    "version": "36028797018963968",
+                    "md5": ""
+                }
+            ]
+        }
+        """
+        let url = writeTempFile(name: "empty.json", content: json)
+
+        XCTAssertThrowsError(try service.parseFile(at: url)) { error in
+            XCTAssertTrue(error is LoadOrderImportService.ImportError)
+        }
+    }
+
+    func testParseInvalidJSONThrows() {
+        let url = writeTempFile(name: "bad.json", content: "{ not valid json }")
+
+        XCTAssertThrowsError(try service.parseFile(at: url)) { error in
+            XCTAssertTrue(error is LoadOrderImportService.ImportError)
+        }
+    }
+
+    func testParseUnknownFormatThrows() {
+        let url = writeTempFile(name: "loadorder.txt", content: "some text")
+
+        XCTAssertThrowsError(try service.parseFile(at: url)) { error in
+            XCTAssertTrue(error is LoadOrderImportService.ImportError)
+        }
+    }
+
+    func testImportedModEntryFields() throws {
+        let json = """
+        {
+            "mods": [
+                {
+                    "modName": "My Mod",
+                    "UUID": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+                    "folder": "MyModFolder",
+                    "version": "72057594037927936",
+                    "md5": "hash123"
+                }
+            ]
+        }
+        """
+        let url = writeTempFile(name: "fields.json", content: json)
+        let result = try service.parseFile(at: url)
+
+        let entry = result.entries.first!
+        XCTAssertEqual(entry.uuid, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        XCTAssertEqual(entry.name, "My Mod")
+        XCTAssertEqual(entry.folder, "MyModFolder")
+        XCTAssertEqual(entry.version64, 72057594037927936)
+        XCTAssertEqual(entry.md5, "hash123")
+    }
+
+    func testVersionFallbackToDefault() throws {
+        let json = """
+        {
+            "mods": [
+                {
+                    "modName": "Bad Version",
+                    "UUID": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    "folder": "BadVer",
+                    "version": "not_a_number",
+                    "md5": ""
+                }
+            ]
+        }
+        """
+        let url = writeTempFile(name: "badversion.json", content: json)
+        let result = try service.parseFile(at: url)
+
+        XCTAssertEqual(result.entries.first?.version64, 36028797018963968)
+    }
+
+    // MARK: - LSX Parsing
+
+    func testParseLSXFile() throws {
+        let lsx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <save>
+            <version major="4" minor="8" revision="0" build="500"/>
+            <region id="ModuleSettings">
+                <node id="root">
+                    <children>
+                        <node id="ModOrder">
+                            <children>
+                                <node id="Module">
+                                    <attribute id="UUID" type="guid" value="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"/>
+                                </node>
+                            </children>
+                        </node>
+                        <node id="Mods">
+                            <children>
+                                <node id="ModuleShortDesc">
+                                    <attribute id="Folder" type="LSString" value="TestMod"/>
+                                    <attribute id="MD5" type="LSString" value="abc123"/>
+                                    <attribute id="Name" type="LSString" value="Test Mod"/>
+                                    <attribute id="UUID" type="guid" value="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"/>
+                                    <attribute id="Version64" type="int64" value="36028797018963968"/>
+                                </node>
+                            </children>
+                        </node>
+                    </children>
+                </node>
+            </region>
+        </save>
+        """
+        let url = writeTempFile(name: "modsettings.lsx", content: lsx)
+        let result = try service.parseFile(at: url)
+
+        XCTAssertEqual(result.format, .lsx)
+        XCTAssertEqual(result.entries.count, 1)
+        XCTAssertEqual(result.entries.first?.name, "Test Mod")
+        XCTAssertEqual(result.sourceName, "modsettings.lsx")
+    }
+
+    func testParseLSXFiltersBuiltInUUIDs() throws {
+        let builtInUUID = Constants.baseModuleUUID
+        let lsx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <save>
+            <version major="4" minor="8" revision="0" build="500"/>
+            <region id="ModuleSettings">
+                <node id="root">
+                    <children>
+                        <node id="ModOrder">
+                            <children>
+                                <node id="Module">
+                                    <attribute id="UUID" type="guid" value="\(builtInUUID)"/>
+                                </node>
+                                <node id="Module">
+                                    <attribute id="UUID" type="guid" value="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"/>
+                                </node>
+                            </children>
+                        </node>
+                        <node id="Mods">
+                            <children>
+                                <node id="ModuleShortDesc">
+                                    <attribute id="Folder" type="LSString" value="GustavX"/>
+                                    <attribute id="MD5" type="LSString" value=""/>
+                                    <attribute id="Name" type="LSString" value="GustavX"/>
+                                    <attribute id="UUID" type="guid" value="\(builtInUUID)"/>
+                                    <attribute id="Version64" type="int64" value="36028797018963968"/>
+                                </node>
+                                <node id="ModuleShortDesc">
+                                    <attribute id="Folder" type="LSString" value="RealMod"/>
+                                    <attribute id="MD5" type="LSString" value="xyz"/>
+                                    <attribute id="Name" type="LSString" value="Real Mod"/>
+                                    <attribute id="UUID" type="guid" value="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"/>
+                                    <attribute id="Version64" type="int64" value="36028797018963968"/>
+                                </node>
+                            </children>
+                        </node>
+                    </children>
+                </node>
+            </region>
+        </save>
+        """
+        let url = writeTempFile(name: "modsettings_builtin.lsx", content: lsx)
+        let result = try service.parseFile(at: url)
+
+        XCTAssertEqual(result.entries.count, 1)
+        XCTAssertEqual(result.entries.first?.name, "Real Mod")
+    }
+
+    // MARK: - ImportError descriptions
+
+    func testImportErrorDescriptions() {
+        let invalidJSON = LoadOrderImportService.ImportError.invalidJSON("bad data")
+        XCTAssertNotNil(invalidJSON.errorDescription)
+        XCTAssertTrue(invalidJSON.errorDescription!.contains("bad data"))
+
+        let unknownFormat = LoadOrderImportService.ImportError.unknownFormat("xyz")
+        XCTAssertNotNil(unknownFormat.errorDescription)
+        XCTAssertTrue(unknownFormat.errorDescription!.contains("xyz"))
+
+        let emptyList = LoadOrderImportService.ImportError.emptyModList
+        XCTAssertNotNil(emptyList.errorDescription)
+    }
+}

--- a/Tests/BG3MacModManagerTests/ModCategoryTests.swift
+++ b/Tests/BG3MacModManagerTests/ModCategoryTests.swift
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class ModCategoryTests: XCTestCase {
+
+    func testRawValues() {
+        XCTAssertEqual(ModCategory.framework.rawValue, 1)
+        XCTAssertEqual(ModCategory.gameplay.rawValue, 2)
+        XCTAssertEqual(ModCategory.contentExtension.rawValue, 3)
+        XCTAssertEqual(ModCategory.visual.rawValue, 4)
+        XCTAssertEqual(ModCategory.lateLoader.rawValue, 5)
+    }
+
+    func testComparable() {
+        XCTAssertTrue(ModCategory.framework < .gameplay)
+        XCTAssertTrue(ModCategory.gameplay < .contentExtension)
+        XCTAssertTrue(ModCategory.contentExtension < .visual)
+        XCTAssertTrue(ModCategory.visual < .lateLoader)
+    }
+
+    func testCaseIterableCount() {
+        XCTAssertEqual(ModCategory.allCases.count, 5)
+    }
+
+    func testDisplayNames() {
+        XCTAssertEqual(ModCategory.framework.displayName, "Framework")
+        XCTAssertEqual(ModCategory.gameplay.displayName, "Gameplay")
+        XCTAssertEqual(ModCategory.contentExtension.displayName, "Content")
+        XCTAssertEqual(ModCategory.visual.displayName, "Visual")
+        XCTAssertEqual(ModCategory.lateLoader.displayName, "Late Loader")
+    }
+
+    func testCodableRoundTrip() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for category in ModCategory.allCases {
+            let data = try encoder.encode(category)
+            let decoded = try decoder.decode(ModCategory.self, from: data)
+            XCTAssertEqual(decoded, category, "Round-trip failed for \(category)")
+        }
+    }
+
+    func testSortOrder() {
+        let unsorted: [ModCategory] = [.lateLoader, .framework, .visual, .gameplay, .contentExtension]
+        let sorted = unsorted.sorted()
+        XCTAssertEqual(sorted, [.framework, .gameplay, .contentExtension, .visual, .lateLoader])
+    }
+}

--- a/Tests/BG3MacModManagerTests/ModInfoTests.swift
+++ b/Tests/BG3MacModManagerTests/ModInfoTests.swift
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class ModInfoTests: XCTestCase {
+
+    // MARK: - Base Game Module
+
+    func testBaseGameModuleHasCorrectUUID() {
+        let base = ModInfo.baseGameModule
+        XCTAssertEqual(base.uuid, Constants.baseModuleUUID)
+    }
+
+    func testBaseGameModuleHasCorrectProperties() {
+        let base = ModInfo.baseGameModule
+        XCTAssertEqual(base.name, "GustavX")
+        XCTAssertEqual(base.folder, "GustavX")
+        XCTAssertEqual(base.author, "Larian Studios")
+        XCTAssertEqual(base.metadataSource, .builtIn)
+        XCTAssertEqual(base.version64, Constants.baseModuleVersion64)
+    }
+
+    func testBaseGameModuleIsBasicGameModule() {
+        XCTAssertTrue(ModInfo.baseGameModule.isBasicGameModule)
+    }
+
+    func testGustavDevUUIDIsBasicGameModule() {
+        let mod = makeModInfo(uuid: Constants.gustavDevUUID)
+        XCTAssertTrue(mod.isBasicGameModule)
+    }
+
+    func testNonGameModuleIsNotBasicGameModule() {
+        let mod = makeModInfo(uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        XCTAssertFalse(mod.isBasicGameModule)
+    }
+
+    // MARK: - fromPakFilename Factory
+
+    func testFromPakFilenameProperties() {
+        let url = URL(fileURLWithPath: "/tmp/CoolMod.pak")
+        let mod = ModInfo.fromPakFilename("CoolMod.pak", at: url)
+
+        XCTAssertEqual(mod.name, "CoolMod")
+        XCTAssertEqual(mod.folder, "CoolMod")
+        XCTAssertEqual(mod.author, "Unknown")
+        XCTAssertEqual(mod.metadataSource, .filename)
+        XCTAssertEqual(mod.pakFileName, "CoolMod.pak")
+        XCTAssertEqual(mod.pakFilePath, url)
+    }
+
+    func testFromPakFilenameDeterministicUUID() {
+        let url = URL(fileURLWithPath: "/tmp/CoolMod.pak")
+        let mod1 = ModInfo.fromPakFilename("CoolMod.pak", at: url)
+        let mod2 = ModInfo.fromPakFilename("CoolMod.pak", at: url)
+        XCTAssertEqual(mod1.uuid, mod2.uuid)
+    }
+
+    func testFromPakFilenameDifferentFilesProduceDifferentUUIDs() {
+        let url = URL(fileURLWithPath: "/tmp/")
+        let mod1 = ModInfo.fromPakFilename("ModA.pak", at: url)
+        let mod2 = ModInfo.fromPakFilename("ModB.pak", at: url)
+        XCTAssertNotEqual(mod1.uuid, mod2.uuid)
+    }
+
+    func testFromPakFilenameCaseInsensitiveUUID() {
+        let url = URL(fileURLWithPath: "/tmp/")
+        let mod1 = ModInfo.fromPakFilename("CoolMod.pak", at: url)
+        let mod2 = ModInfo.fromPakFilename("coolmod.pak", at: url)
+        XCTAssertEqual(mod1.uuid, mod2.uuid)
+    }
+
+    // MARK: - Computed Properties
+
+    func testVersionComputedProperty() {
+        let mod = makeModInfo(version64: 36028797018963968)
+        let expected = Version64(major: 1, minor: 0, revision: 0, build: 0)
+        XCTAssertEqual(mod.version, expected)
+    }
+
+    // MARK: - MetadataSource Priority
+
+    func testMetadataSourcePriorityOrder() {
+        XCTAssertGreaterThan(MetadataSource.builtIn.priority, MetadataSource.metaLsx.priority)
+        XCTAssertGreaterThan(MetadataSource.metaLsx.priority, MetadataSource.infoJson.priority)
+        XCTAssertGreaterThan(MetadataSource.infoJson.priority, MetadataSource.modSettings.priority)
+        XCTAssertGreaterThan(MetadataSource.modSettings.priority, MetadataSource.filename.priority)
+    }
+
+    func testMetadataSourceCodableRoundTrip() throws {
+        let sources: [MetadataSource] = [.infoJson, .metaLsx, .filename, .builtIn, .modSettings]
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for source in sources {
+            let data = try encoder.encode(source)
+            let decoded = try decoder.decode(MetadataSource.self, from: data)
+            XCTAssertEqual(decoded, source, "Round-trip failed for \(source)")
+        }
+    }
+
+    // MARK: - Constants
+
+    func testBuiltInModuleUUIDsContainsKnownUUIDs() {
+        XCTAssertTrue(Constants.builtInModuleUUIDs.contains(Constants.baseModuleUUID))
+        XCTAssertTrue(Constants.builtInModuleUUIDs.contains(Constants.gustavDevUUID))
+    }
+
+    func testBuiltInModuleUUIDsCount() {
+        XCTAssertEqual(Constants.builtInModuleUUIDs.count, 19)
+    }
+}

--- a/Tests/BG3MacModManagerTests/ModValidationServiceTests.swift
+++ b/Tests/BG3MacModManagerTests/ModValidationServiceTests.swift
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class ModValidationServiceTests: XCTestCase {
+
+    var service: ModValidationService!
+
+    override func setUp() {
+        super.setUp()
+        service = ModValidationService()
+    }
+
+    /// Helper: filter warnings by category from a validate() result.
+    private func warnings(
+        _ category: ModWarning.Category,
+        activeMods: [ModInfo] = [],
+        inactiveMods: [ModInfo] = [],
+        seStatus: ScriptExtenderService.SEStatus? = nil,
+        seWasPreviouslyDeployed: Bool = false
+    ) -> [ModWarning] {
+        service.validate(
+            activeMods: activeMods,
+            inactiveMods: inactiveMods,
+            seStatus: seStatus,
+            seWasPreviouslyDeployed: seWasPreviouslyDeployed
+        ).filter { $0.category == category }
+    }
+
+    // MARK: - Duplicate UUIDs
+
+    func testNoDuplicatesNoWarning() {
+        let modA = makeModInfo(uuid: "aaa", name: "Mod A")
+        let modB = makeModInfo(uuid: "bbb", name: "Mod B")
+        let result = warnings(.duplicateUUID, activeMods: [modA, modB])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testDuplicateUUIDInActiveMods() {
+        let modA = makeModInfo(uuid: "same-uuid", name: "Mod A", pakFileName: "A.pak")
+        let modB = makeModInfo(uuid: "same-uuid", name: "Mod B", pakFileName: "B.pak")
+        let result = warnings(.duplicateUUID, activeMods: [modA, modB])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .critical)
+    }
+
+    func testDuplicateUUIDCrossActiveInactive() {
+        let active = makeModInfo(uuid: "same-uuid", name: "Active", pakFileName: "A.pak")
+        let inactive = makeModInfo(uuid: "same-uuid", name: "Inactive", pakFileName: "B.pak")
+        let result = warnings(.duplicateUUID, activeMods: [active], inactiveMods: [inactive])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .critical)
+    }
+
+    // MARK: - Missing Dependencies
+
+    func testNoDependenciesNoWarning() {
+        let mod = makeModInfo(uuid: "aaa", name: "No Deps")
+        let result = warnings(.missingDependency, activeMods: [mod])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testMissingDependencyNotInstalled() {
+        let depUUID = "dep-uuid-missing"
+        let dep = makeDependency(uuid: depUUID, name: "Missing Dep")
+        let mod = makeModInfo(uuid: "aaa", name: "Mod A", dependencies: [dep])
+        let result = warnings(.missingDependency, activeMods: [mod])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .warning)
+        XCTAssertTrue(result.first?.message.contains("Missing Dep") ?? false)
+    }
+
+    func testDependencyInInactiveListSuggestsActivation() {
+        let depUUID = "dep-uuid-inactive"
+        let dep = makeDependency(uuid: depUUID, name: "Inactive Dep")
+        let mod = makeModInfo(uuid: "aaa", name: "Mod A", dependencies: [dep])
+        let inactiveMod = makeModInfo(uuid: depUUID, name: "Inactive Dep")
+        let result = warnings(.missingDependency, activeMods: [mod], inactiveMods: [inactiveMod])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.suggestedAction, .activateDependencies(modUUID: "aaa"))
+    }
+
+    func testDependencyInActiveListNoWarning() {
+        let depUUID = "dep-uuid-active"
+        let dep = makeDependency(uuid: depUUID, name: "Active Dep")
+        let mod = makeModInfo(uuid: "aaa", name: "Mod A", dependencies: [dep])
+        let depMod = makeModInfo(uuid: depUUID, name: "Active Dep")
+        let result = warnings(.missingDependency, activeMods: [mod, depMod])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testBuiltInDependencyIgnored() {
+        let builtInUUID = Constants.builtInModuleUUIDs.first!
+        let dep = makeDependency(uuid: builtInUUID, name: "Built-in")
+        let mod = makeModInfo(uuid: "aaa", name: "Mod A", dependencies: [dep])
+        let result = warnings(.missingDependency, activeMods: [mod])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Dependency Load Order
+
+    func testCorrectDependencyOrderNoWarning() {
+        let depUUID = "dep-uuid"
+        let dep = makeDependency(uuid: depUUID, name: "Dep")
+        let depMod = makeModInfo(uuid: depUUID, name: "Dep") // position 0
+        let mod = makeModInfo(uuid: "aaa", name: "Mod A", dependencies: [dep]) // position 1
+        let result = warnings(.wrongLoadOrder, activeMods: [depMod, mod])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testWrongDependencyOrderWarning() {
+        let depUUID = "dep-uuid"
+        let dep = makeDependency(uuid: depUUID, name: "Dep")
+        let mod = makeModInfo(uuid: "aaa", name: "Mod A", dependencies: [dep]) // position 0
+        let depMod = makeModInfo(uuid: depUUID, name: "Dep") // position 1 (after dependent)
+        let result = warnings(.wrongLoadOrder, activeMods: [mod, depMod])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .warning)
+        XCTAssertEqual(result.first?.suggestedAction, .autoSort)
+    }
+
+    func testBuiltInDependencyOrderIgnored() {
+        let builtInUUID = Constants.builtInModuleUUIDs.first!
+        let dep = makeDependency(uuid: builtInUUID, name: "Built-in")
+        let mod = makeModInfo(uuid: "aaa", name: "Mod A", dependencies: [dep])
+        let result = warnings(.wrongLoadOrder, activeMods: [mod])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Circular Dependencies
+
+    func testNoCycleNoWarning() {
+        let depUUID = "dep-uuid"
+        let dep = makeDependency(uuid: depUUID, name: "Dep")
+        let modA = makeModInfo(uuid: "aaa", name: "Mod A", dependencies: [dep])
+        let modB = makeModInfo(uuid: depUUID, name: "Dep")
+        let result = warnings(.circularDependency, activeMods: [modA, modB])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testDirectCycleWarning() {
+        let depAB = makeDependency(uuid: "bbb", name: "Mod B")
+        let depBA = makeDependency(uuid: "aaa", name: "Mod A")
+        let modA = makeModInfo(uuid: "aaa", name: "Mod A", dependencies: [depAB])
+        let modB = makeModInfo(uuid: "bbb", name: "Mod B", dependencies: [depBA])
+        let result = warnings(.circularDependency, activeMods: [modA, modB])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .critical)
+    }
+
+    func testTransitiveCycleWarning() {
+        let depAB = makeDependency(uuid: "bbb", name: "B")
+        let depBC = makeDependency(uuid: "ccc", name: "C")
+        let depCA = makeDependency(uuid: "aaa", name: "A")
+        let modA = makeModInfo(uuid: "aaa", name: "A", dependencies: [depAB])
+        let modB = makeModInfo(uuid: "bbb", name: "B", dependencies: [depBC])
+        let modC = makeModInfo(uuid: "ccc", name: "C", dependencies: [depCA])
+        let result = warnings(.circularDependency, activeMods: [modA, modB, modC])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .critical)
+    }
+
+    // MARK: - Conflicting Mods
+
+    func testNoConflictsNoWarning() {
+        let modA = makeModInfo(uuid: "aaa", name: "Mod A")
+        let modB = makeModInfo(uuid: "bbb", name: "Mod B")
+        let result = warnings(.conflictingMods, activeMods: [modA, modB])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testConflictBothActiveWarning() {
+        let conflictB = makeDependency(uuid: "bbb", name: "Mod B")
+        let modA = makeModInfo(uuid: "aaa", name: "Mod A", conflicts: [conflictB])
+        let modB = makeModInfo(uuid: "bbb", name: "Mod B")
+        let result = warnings(.conflictingMods, activeMods: [modA, modB])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .warning)
+    }
+
+    func testConflictOneInactiveNoWarning() {
+        let conflictB = makeDependency(uuid: "bbb", name: "Mod B")
+        let modA = makeModInfo(uuid: "aaa", name: "Mod A", conflicts: [conflictB])
+        let modB = makeModInfo(uuid: "bbb", name: "Mod B")
+        let result = warnings(.conflictingMods, activeMods: [modA], inactiveMods: [modB])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testMutualConflictOnlyOneWarning() {
+        let conflictB = makeDependency(uuid: "bbb", name: "Mod B")
+        let conflictA = makeDependency(uuid: "aaa", name: "Mod A")
+        let modA = makeModInfo(uuid: "aaa", name: "Mod A", conflicts: [conflictB])
+        let modB = makeModInfo(uuid: "bbb", name: "Mod B", conflicts: [conflictA])
+        let result = warnings(.conflictingMods, activeMods: [modA, modB])
+        XCTAssertEqual(result.count, 1) // Deduped via canonical pair
+    }
+
+    // MARK: - Phantom Mods
+
+    func testPhantomModWarning() {
+        let mod = makeModInfo(uuid: "aaa", name: "Phantom", metadataSource: .modSettings)
+        let result = warnings(.phantomMod, activeMods: [mod])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .critical)
+    }
+
+    func testNonPhantomModNoWarning() {
+        let mod = makeModInfo(uuid: "aaa", name: "Real Mod", metadataSource: .metaLsx)
+        let result = warnings(.phantomMod, activeMods: [mod])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testBaseGameModuleNotPhantom() {
+        // Base game module with modSettings source should NOT be flagged
+        let mod = makeModInfo(
+            uuid: Constants.baseModuleUUID,
+            name: "GustavX",
+            metadataSource: .modSettings
+        )
+        let result = warnings(.phantomMod, activeMods: [mod])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Script Extender Requirements
+
+    func testSERequiredButNotDeployed() {
+        let mod = makeModInfo(uuid: "aaa", name: "SE Mod", requiresScriptExtender: true)
+        let status = makeSEStatus(isDeployed: false)
+        let result = warnings(.seRequired, activeMods: [mod], seStatus: status)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .critical)
+        XCTAssertEqual(result.first?.suggestedAction, .installScriptExtender)
+    }
+
+    func testSERequiredAndDeployed() {
+        let mod = makeModInfo(uuid: "aaa", name: "SE Mod", requiresScriptExtender: true)
+        let status = makeSEStatus(isDeployed: true)
+        let result = warnings(.seRequired, activeMods: [mod], seStatus: status)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testSERequiredNilStatus() {
+        let mod = makeModInfo(uuid: "aaa", name: "SE Mod", requiresScriptExtender: true)
+        let result = warnings(.seRequired, activeMods: [mod], seStatus: nil)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .critical)
+    }
+
+    func testNoSEModsNoWarning() {
+        let mod = makeModInfo(uuid: "aaa", name: "Normal Mod", requiresScriptExtender: false)
+        let result = warnings(.seRequired, activeMods: [mod], seStatus: nil)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - No Metadata
+
+    func testNoMetadataModWarning() {
+        let mod = makeModInfo(uuid: "aaa", name: "No Meta", metadataSource: .filename)
+        let result = warnings(.noMetadata, activeMods: [mod])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .info)
+    }
+
+    func testMetadataModNoWarning() {
+        let mod = makeModInfo(uuid: "aaa", name: "Has Meta", metadataSource: .metaLsx)
+        let result = warnings(.noMetadata, activeMods: [mod])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testNoMetadataInInactiveMods() {
+        let mod = makeModInfo(uuid: "aaa", name: "No Meta Inactive", metadataSource: .filename)
+        let result = warnings(.noMetadata, inactiveMods: [mod])
+        XCTAssertEqual(result.count, 1)
+    }
+
+    // MARK: - SE Disappeared
+
+    func testSEDisappearedWarning() {
+        let status = makeSEStatus(isDeployed: false)
+        let result = warnings(
+            .seDisappeared,
+            seStatus: status,
+            seWasPreviouslyDeployed: true
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .warning)
+        XCTAssertEqual(result.first?.suggestedAction, .viewSEStatus)
+    }
+
+    func testSENotPreviouslyDeployedNoWarning() {
+        let status = makeSEStatus(isDeployed: false)
+        let result = warnings(
+            .seDisappeared,
+            seStatus: status,
+            seWasPreviouslyDeployed: false
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testSEStillDeployedNoWarning() {
+        let status = makeSEStatus(isDeployed: true)
+        let result = warnings(
+            .seDisappeared,
+            seStatus: status,
+            seWasPreviouslyDeployed: true
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Topological Sort
+
+    func testTopologicalSortNoDependencies() {
+        let modA = makeModInfo(uuid: "aaa", name: "A")
+        let modB = makeModInfo(uuid: "bbb", name: "B")
+        let sorted = service.topologicalSort(mods: [modA, modB])
+        XCTAssertNotNil(sorted)
+        XCTAssertEqual(sorted?.count, 2)
+    }
+
+    func testTopologicalSortSimpleChain() {
+        let dep = makeDependency(uuid: "bbb", name: "B")
+        let modA = makeModInfo(uuid: "aaa", name: "A", dependencies: [dep])
+        let modB = makeModInfo(uuid: "bbb", name: "B")
+
+        let sorted = service.topologicalSort(mods: [modA, modB])
+        XCTAssertNotNil(sorted)
+        // B should come before A since A depends on B
+        let indexB = sorted!.firstIndex(where: { $0.uuid == "bbb" })!
+        let indexA = sorted!.firstIndex(where: { $0.uuid == "aaa" })!
+        XCTAssertTrue(indexB < indexA)
+    }
+
+    func testTopologicalSortCycleReturnsNil() {
+        let depAB = makeDependency(uuid: "bbb", name: "B")
+        let depBA = makeDependency(uuid: "aaa", name: "A")
+        let modA = makeModInfo(uuid: "aaa", name: "A", dependencies: [depAB])
+        let modB = makeModInfo(uuid: "bbb", name: "B", dependencies: [depBA])
+
+        let sorted = service.topologicalSort(mods: [modA, modB])
+        XCTAssertNil(sorted)
+    }
+
+    func testTopologicalSortIgnoresExternalDependencies() {
+        // Dependency on a UUID not in the input array should be ignored
+        let externalDep = makeDependency(uuid: "external-uuid", name: "External")
+        let modA = makeModInfo(uuid: "aaa", name: "A", dependencies: [externalDep])
+
+        let sorted = service.topologicalSort(mods: [modA])
+        XCTAssertNotNil(sorted)
+        XCTAssertEqual(sorted?.count, 1)
+    }
+
+    // MARK: - Aggregate / validateForSave
+
+    func testValidateForSaveFiltersInfoSeverity() {
+        // Create a mod that triggers .info (no metadata) and .warning (missing dep)
+        let dep = makeDependency(uuid: "missing-dep", name: "Missing")
+        let mod = makeModInfo(
+            uuid: "aaa",
+            name: "Test Mod",
+            dependencies: [dep],
+            metadataSource: .filename
+        )
+
+        let allWarnings = service.validate(
+            activeMods: [mod],
+            inactiveMods: [],
+            seStatus: nil
+        )
+        let infoWarnings = allWarnings.filter { $0.severity == .info }
+        XCTAssertFalse(infoWarnings.isEmpty, "Should have at least one info warning")
+
+        let saveWarnings = service.validateForSave(
+            activeMods: [mod],
+            inactiveMods: [],
+            seStatus: nil
+        )
+        let saveInfoWarnings = saveWarnings.filter { $0.severity == .info }
+        XCTAssertTrue(saveInfoWarnings.isEmpty, "validateForSave should exclude info severity")
+    }
+
+    func testValidateReturnsSortedBySeverity() {
+        // Create conditions that produce both critical and info warnings
+        let phantomMod = makeModInfo(uuid: "phantom", name: "Phantom", metadataSource: .modSettings)
+        let noMetaMod = makeModInfo(uuid: "nometa", name: "No Meta", metadataSource: .filename)
+
+        let allWarnings = service.validate(
+            activeMods: [phantomMod, noMetaMod],
+            inactiveMods: [],
+            seStatus: nil
+        )
+
+        // Verify sorted: critical first, then warning, then info
+        var lastSeverity: ModWarning.Severity = .critical
+        for warning in allWarnings {
+            XCTAssertTrue(
+                warning.severity <= lastSeverity,
+                "Warnings should be sorted by severity descending"
+            )
+            lastSeverity = warning.severity
+        }
+    }
+}

--- a/Tests/BG3MacModManagerTests/PakReaderTests.swift
+++ b/Tests/BG3MacModManagerTests/PakReaderTests.swift
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class PakReaderTests: XCTestCase {
+
+    var tempFiles: [URL] = []
+
+    override func tearDown() {
+        for url in tempFiles {
+            try? FileManager.default.removeItem(at: url)
+        }
+        tempFiles.removeAll()
+        super.tearDown()
+    }
+
+    /// Write binary data to a temporary file and track it for cleanup.
+    private func writeTempBinary(name: String, data: Data) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bg3test_\(UUID().uuidString)_\(name)")
+        try! data.write(to: url)
+        tempFiles.append(url)
+        return url
+    }
+
+    // MARK: - Signature Validation
+
+    func testInvalidSignatureThrows() {
+        // 4 bytes of wrong signature + 36 bytes of header padding = 40 bytes total
+        var data = Data([0x00, 0x00, 0x00, 0x00])
+        data.append(Data(count: 36))
+        let url = writeTempBinary(name: "bad_sig.pak", data: data)
+
+        XCTAssertThrowsError(try PakReader.listFiles(at: url)) { error in
+            guard let pakError = error as? PakReader.PakError else {
+                XCTFail("Expected PakError, got \(error)")
+                return
+            }
+            if case .invalidSignature = pakError {
+                // Expected
+            } else {
+                XCTFail("Expected invalidSignature, got \(pakError)")
+            }
+        }
+    }
+
+    func testTooSmallDataThrows() {
+        let data = Data([0x4C, 0x53]) // Only 2 bytes, not enough for signature
+        let url = writeTempBinary(name: "tiny.pak", data: data)
+
+        XCTAssertThrowsError(try PakReader.listFiles(at: url))
+    }
+
+    func testEmptyFileThrows() {
+        let data = Data()
+        let url = writeTempBinary(name: "empty.pak", data: data)
+
+        XCTAssertThrowsError(try PakReader.listFiles(at: url))
+    }
+
+    // MARK: - Version Validation
+
+    func testUnsupportedVersionThrows() {
+        // Valid "LSPK" signature + version 99
+        var data = Data([0x4C, 0x53, 0x50, 0x4B]) // "LSPK"
+        // Version 99 as UInt32 little-endian
+        data.append(contentsOf: [0x63, 0x00, 0x00, 0x00])
+        // Pad remaining header bytes (28 bytes)
+        data.append(Data(count: 28))
+        let url = writeTempBinary(name: "bad_version.pak", data: data)
+
+        XCTAssertThrowsError(try PakReader.listFiles(at: url)) { error in
+            guard let pakError = error as? PakReader.PakError else {
+                XCTFail("Expected PakError, got \(error)")
+                return
+            }
+            if case .unsupportedVersion(let v) = pakError {
+                XCTAssertEqual(v, 99)
+            } else {
+                XCTFail("Expected unsupportedVersion, got \(pakError)")
+            }
+        }
+    }
+
+    func testVersion18PassesVersionCheck() {
+        // Valid signature + version 18 but zeroed file list offset
+        // Should fail on file list read, not on version check
+        var data = Data([0x4C, 0x53, 0x50, 0x4B]) // "LSPK"
+        data.append(contentsOf: [0x12, 0x00, 0x00, 0x00]) // version 18
+        data.append(Data(count: 28)) // rest of header zeroed
+        let url = writeTempBinary(name: "v18.pak", data: data)
+
+        XCTAssertThrowsError(try PakReader.listFiles(at: url)) { error in
+            guard let pakError = error as? PakReader.PakError else {
+                // FileHandle or other error is also acceptable here
+                return
+            }
+            // Should NOT be unsupportedVersion
+            if case .unsupportedVersion = pakError {
+                XCTFail("Version 18 should not throw unsupportedVersion")
+            }
+        }
+    }
+
+    // MARK: - Nonexistent File
+
+    func testListFilesOnNonexistentPathThrows() {
+        let url = URL(fileURLWithPath: "/tmp/nonexistent_\(UUID().uuidString).pak")
+        XCTAssertThrowsError(try PakReader.listFiles(at: url))
+    }
+
+    func testExtractFileFromNonexistentPathThrows() {
+        let url = URL(fileURLWithPath: "/tmp/nonexistent_\(UUID().uuidString).pak")
+        XCTAssertThrowsError(try PakReader.extractFile(named: "meta.lsx", from: url))
+    }
+
+    // MARK: - containsScriptExtender Graceful Handling
+
+    func testContainsScriptExtenderReturnsFalseForInvalidFile() {
+        let data = Data([0x00, 0x01, 0x02, 0x03])
+        let url = writeTempBinary(name: "not_a_pak.bin", data: data)
+        XCTAssertFalse(PakReader.containsScriptExtender(at: url))
+    }
+
+    func testContainsScriptExtenderReturnsFalseForNonexistentFile() {
+        let url = URL(fileURLWithPath: "/tmp/nonexistent_\(UUID().uuidString).pak")
+        XCTAssertFalse(PakReader.containsScriptExtender(at: url))
+    }
+
+    // MARK: - CompressionType Enum
+
+    func testCompressionTypeNone() {
+        XCTAssertEqual(PakReader.CompressionType(rawValue: 0), .none)
+    }
+
+    func testCompressionTypeZlib() {
+        XCTAssertEqual(PakReader.CompressionType(rawValue: 1), .zlib)
+    }
+
+    func testCompressionTypeLZ4() {
+        XCTAssertEqual(PakReader.CompressionType(rawValue: 2), .lz4)
+    }
+
+    func testCompressionTypeUnknownReturnsNil() {
+        XCTAssertNil(PakReader.CompressionType(rawValue: 99))
+    }
+
+    // MARK: - PakError Descriptions
+
+    func testPakErrorDescriptions() {
+        let errors: [PakReader.PakError] = [
+            .invalidSignature,
+            .unsupportedVersion(14),
+            .fileListReadFailed,
+            .decompressionFailed,
+            .fileNotFound("meta.lsx"),
+            .readError("test error"),
+        ]
+
+        for error in errors {
+            XCTAssertNotNil(error.errorDescription, "Missing description for \(error)")
+            XCTAssertFalse(error.errorDescription!.isEmpty)
+        }
+    }
+
+    func testPakErrorFileNotFoundIncludesFilename() {
+        let error = PakReader.PakError.fileNotFound("Mods/Test/meta.lsx")
+        XCTAssertTrue(error.errorDescription!.contains("Mods/Test/meta.lsx"))
+    }
+
+    func testPakErrorUnsupportedVersionIncludesVersion() {
+        let error = PakReader.PakError.unsupportedVersion(14)
+        XCTAssertTrue(error.errorDescription!.contains("14"))
+    }
+}

--- a/Tests/BG3MacModManagerTests/TestHelpers.swift
+++ b/Tests/BG3MacModManagerTests/TestHelpers.swift
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+@testable import BG3MacModManager
+
+/// Creates a ModInfo with sensible defaults. Override any field as needed.
+func makeModInfo(
+    uuid: String = UUID().uuidString.lowercased(),
+    folder: String = "TestMod",
+    name: String = "Test Mod",
+    author: String = "Test Author",
+    modDescription: String = "",
+    version64: Int64 = 36028797018963968, // 1.0.0.0
+    md5: String = "",
+    tags: [String] = [],
+    dependencies: [ModDependency] = [],
+    conflicts: [ModDependency] = [],
+    requiresScriptExtender: Bool = false,
+    pakFileName: String? = "TestMod.pak",
+    pakFilePath: URL? = nil,
+    metadataSource: MetadataSource = .metaLsx,
+    category: ModCategory? = nil
+) -> ModInfo {
+    ModInfo(
+        uuid: uuid,
+        folder: folder,
+        name: name,
+        author: author,
+        modDescription: modDescription,
+        version64: version64,
+        md5: md5,
+        tags: tags,
+        dependencies: dependencies,
+        conflicts: conflicts,
+        requiresScriptExtender: requiresScriptExtender,
+        pakFileName: pakFileName,
+        pakFilePath: pakFilePath,
+        metadataSource: metadataSource,
+        category: category
+    )
+}
+
+/// Creates a ModDependency with sensible defaults.
+func makeDependency(
+    uuid: String = UUID().uuidString.lowercased(),
+    folder: String = "DepFolder",
+    name: String = "Dependency",
+    version64: Int64 = 36028797018963968,
+    md5: String = ""
+) -> ModDependency {
+    ModDependency(
+        uuid: uuid,
+        folder: folder,
+        name: name,
+        version64: version64,
+        md5: md5
+    )
+}
+
+/// Creates a ScriptExtenderService.SEStatus with sensible defaults.
+func makeSEStatus(
+    isInstalled: Bool = false,
+    isDeployed: Bool = false,
+    dylibPath: URL? = nil,
+    logsAvailable: Bool = false,
+    latestLogPath: URL? = nil
+) -> ScriptExtenderService.SEStatus {
+    ScriptExtenderService.SEStatus(
+        isInstalled: isInstalled,
+        isDeployed: isDeployed,
+        dylibPath: dylibPath,
+        logsAvailable: logsAvailable,
+        latestLogPath: latestLogPath
+    )
+}

--- a/Tests/BG3MacModManagerTests/TextExportServiceTests.swift
+++ b/Tests/BG3MacModManagerTests/TextExportServiceTests.swift
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class TextExportServiceTests: XCTestCase {
+
+    var service: TextExportService!
+
+    override func setUp() {
+        super.setUp()
+        service = TextExportService()
+    }
+
+    // MARK: - Test Data
+
+    private func sampleMods() -> [ModInfo] {
+        [
+            makeModInfo(uuid: "aaa", name: "Alpha Mod", author: "Alice", tags: ["gameplay"]),
+            makeModInfo(uuid: "bbb", name: "Beta Mod", author: "Bob", tags: ["visual"], requiresScriptExtender: true),
+        ]
+    }
+
+    // MARK: - CSV Format
+
+    func testCSVHeaderRow() {
+        let output = service.export(activeMods: sampleMods(), format: .csv)
+        let firstLine = output.components(separatedBy: "\r\n").first!
+        XCTAssertTrue(firstLine.contains("Position"))
+        XCTAssertTrue(firstLine.contains("Name"))
+        XCTAssertTrue(firstLine.contains("Author"))
+        XCTAssertTrue(firstLine.contains("UUID"))
+        XCTAssertTrue(firstLine.contains("Version"))
+        XCTAssertTrue(firstLine.contains("PAK File"))
+    }
+
+    func testCSVRowCount() {
+        let mods = sampleMods()
+        let output = service.export(activeMods: mods, format: .csv)
+        let lines = output.components(separatedBy: "\r\n").filter { !$0.isEmpty }
+        // 1 header + N data rows
+        XCTAssertEqual(lines.count, mods.count + 1)
+    }
+
+    func testCSVContainsModNames() {
+        let output = service.export(activeMods: sampleMods(), format: .csv)
+        XCTAssertTrue(output.contains("Alpha Mod"))
+        XCTAssertTrue(output.contains("Beta Mod"))
+    }
+
+    func testCSVEscapesCommas() {
+        let mods = [makeModInfo(name: "Mod, With Comma", author: "Auth")]
+        let output = service.export(activeMods: mods, format: .csv)
+        XCTAssertTrue(output.contains("\"Mod, With Comma\""))
+    }
+
+    func testCSVEscapesDoubleQuotes() {
+        let mods = [makeModInfo(name: "Mod \"Quoted\"", author: "Auth")]
+        let output = service.export(activeMods: mods, format: .csv)
+        XCTAssertTrue(output.contains("\"Mod \"\"Quoted\"\"\""))
+    }
+
+    func testCSVEmptyModList() {
+        let output = service.export(activeMods: [], format: .csv)
+        let lines = output.components(separatedBy: "\r\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 1) // Header only
+    }
+
+    func testCSVLineEndingsAreCRLF() {
+        let output = service.export(activeMods: sampleMods(), format: .csv)
+        // Should contain \r\n and end with \r\n
+        XCTAssertTrue(output.contains("\r\n"))
+        XCTAssertTrue(output.hasSuffix("\r\n"))
+    }
+
+    func testCSVPositionNumbers() {
+        let output = service.export(activeMods: sampleMods(), format: .csv)
+        let lines = output.components(separatedBy: "\r\n").filter { !$0.isEmpty }
+        // Data rows start with position number
+        XCTAssertTrue(lines[1].hasPrefix("1,"))
+        XCTAssertTrue(lines[2].hasPrefix("2,"))
+    }
+
+    // MARK: - Markdown Format
+
+    func testMarkdownHeader() {
+        let output = service.export(activeMods: sampleMods(), format: .markdown)
+        XCTAssertTrue(output.hasPrefix("# Mod Load Order"))
+    }
+
+    func testMarkdownTableStructure() {
+        let output = service.export(activeMods: sampleMods(), format: .markdown)
+        let lines = output.components(separatedBy: "\n")
+        // Should have header row with pipes and separator row
+        let headerLine = lines.first { $0.contains("| # |") }
+        XCTAssertNotNil(headerLine)
+        let separatorLine = lines.first { $0.contains("|---|") }
+        XCTAssertNotNil(separatorLine)
+    }
+
+    func testMarkdownContainsModNames() {
+        let output = service.export(activeMods: sampleMods(), format: .markdown)
+        XCTAssertTrue(output.contains("Alpha Mod"))
+        XCTAssertTrue(output.contains("Beta Mod"))
+    }
+
+    func testMarkdownPipeEscaping() {
+        let mods = [makeModInfo(name: "Mod|With|Pipes", author: "Auth")]
+        let output = service.export(activeMods: mods, format: .markdown)
+        XCTAssertTrue(output.contains("Mod\\|With\\|Pipes"))
+    }
+
+    func testMarkdownTotalLine() {
+        let mods = sampleMods()
+        let output = service.export(activeMods: mods, format: .markdown)
+        XCTAssertTrue(output.contains("**Total:** \(mods.count) active mods"))
+    }
+
+    func testMarkdownTotalLineSingular() {
+        let mods = [makeModInfo(name: "Only Mod")]
+        let output = service.export(activeMods: mods, format: .markdown)
+        XCTAssertTrue(output.contains("**Total:** 1 active mod"))
+        // Should NOT have "mods" (plural)
+        XCTAssertFalse(output.contains("1 active mods"))
+    }
+
+    // MARK: - Plain Text Format
+
+    func testPlainTextNumberedList() {
+        let output = service.export(activeMods: sampleMods(), format: .plainText)
+        XCTAssertTrue(output.contains("1. Alpha Mod"))
+        XCTAssertTrue(output.contains("2. Beta Mod"))
+    }
+
+    func testPlainTextContainsVersionAndAuthor() {
+        let output = service.export(activeMods: sampleMods(), format: .plainText)
+        XCTAssertTrue(output.contains("by Alice"))
+        XCTAssertTrue(output.contains("by Bob"))
+    }
+
+    func testPlainTextContainsUUID() {
+        let output = service.export(activeMods: sampleMods(), format: .plainText)
+        XCTAssertTrue(output.contains("UUID: aaa"))
+        XCTAssertTrue(output.contains("UUID: bbb"))
+    }
+
+    func testPlainTextTotalLine() {
+        let mods = sampleMods()
+        let output = service.export(activeMods: mods, format: .plainText)
+        XCTAssertTrue(output.contains("Total: \(mods.count) active mods"))
+    }
+
+    func testPlainTextRequiresSEIndicator() {
+        let output = service.export(activeMods: sampleMods(), format: .plainText)
+        XCTAssertTrue(output.contains("Requires SE"))
+    }
+
+    // MARK: - ExportFormat Properties
+
+    func testExportFormatFileExtensions() {
+        XCTAssertEqual(TextExportService.ExportFormat.csv.fileExtension, "csv")
+        XCTAssertEqual(TextExportService.ExportFormat.markdown.fileExtension, "md")
+        XCTAssertEqual(TextExportService.ExportFormat.plainText.fileExtension, "txt")
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a comprehensive test suite covering core services, models, and utilities in the BG3 Mod Manager. The test suite includes 8 new test files with 100+ test cases covering validation, import, export, category inference, and data parsing functionality.

## Key Changes

### Test Files Added
- **ModValidationServiceTests.swift** (404 lines)
  - Tests all 10 validation categories: duplicate UUIDs, missing dependencies, wrong load order, circular dependencies, conflicting mods, phantom mods, script extender requirements, no metadata, SE disappeared, and SE not deployed
  - Includes tests for dependency resolution, topological sorting, and edge cases (built-in modules, inactive mods, etc.)

- **LoadOrderImportServiceTests.swift** (293 lines)
  - Tests BG3MM JSON format parsing with UUID normalization and built-in mod filtering
  - Tests LSX file parsing with proper attribute extraction
  - Tests error handling for invalid files, empty mod lists, and malformed data

- **CategoryInferenceServiceTests.swift** (200 lines)
  - Tests tag-based heuristics for all 5 mod categories (framework, gameplay, content extension, visual, late loader)
  - Tests name-based heuristics and priority ordering
  - Tests override persistence and clearing

- **TextExportServiceTests.swift** (165 lines)
  - Tests CSV export with proper escaping of commas and quotes, CRLF line endings
  - Tests Markdown export with table formatting and pipe escaping
  - Tests plain text numbered list format

- **PakReaderTests.swift** (176 lines)
  - Tests PAK file signature and version validation
  - Tests error handling for corrupted/invalid files
  - Tests CompressionType enum and graceful failure modes

- **ModInfoTests.swift** (112 lines)
  - Tests base game module properties and UUID detection
  - Tests ModInfo factory methods with deterministic UUID generation
  - Tests MetadataSource priority ordering

- **DataBinaryReadingTests.swift** (79 lines)
  - Tests Data extension methods for reading UInt16, UInt32, UInt64, and Int64 in little-endian format
  - Tests boundary conditions and out-of-bounds access

- **ModCategoryTests.swift** (51 lines)
  - Tests ModCategory enum raw values, ordering, and display names
  - Tests Codable round-trip serialization

### Test Helpers
- **TestHelpers.swift** (75 lines)
  - Factory functions: `makeModInfo()`, `makeDependency()`, `makeSEStatus()`
  - Provides sensible defaults for all test data creation

### Documentation
- Updated **CLAUDE.md** with test file descriptions and organization

## Notable Implementation Details

- All tests use GPL-3.0-or-later license headers
- Comprehensive edge case coverage including circular dependency detection, built-in module filtering, and graceful error handling
- Tests validate both happy paths and error conditions
- Proper resource cleanup (temporary files) in tearDown methods
- Factory functions with optional parameters for flexible test data creation
- Tests verify both positive cases (no warnings) and negative cases (warnings generated)

https://claude.ai/code/session_017LF9U9vhgwyurUDdE5s8h2