### PR TITLE
Add Nexus Mods integration: bulk URL import, update checking, and mod notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-BG3 Mac Mod Manager is a macOS SwiftUI application for managing Baldur's Gate 3 mods. It uses Swift Package Manager (SPM) with swift-tools-version 5.9, targeting macOS 13+. Current release: **v1.0.6**.
+BG3 Mac Mod Manager is a macOS SwiftUI application for managing Baldur's Gate 3 mods. It uses Swift Package Manager (SPM) with swift-tools-version 5.9, targeting macOS 13+. Current release: **v1.1.0**.
 
 ## Build Environment
 
@@ -13,10 +13,10 @@ BG3 Mac Mod Manager is a macOS SwiftUI application for managing Baldur's Gate 3 
 ```
 Sources/BG3MacModManager/
   App/          - App entry point (BG3MacModManagerApp), AppState
-  Models/       - Data models (ModModel, ModCategory, etc.)
-  Services/     - Business logic (ModService, LaunchService, etc.)
+  Models/       - Data models (ModModel, ModCategory, NexusUpdateInfo, etc.)
+  Services/     - Business logic (ModService, LaunchService, ModNotesService, NexusAPIService, NexusURLImportService, etc.)
   Utilities/    - Helpers (FileLocations, etc.)
-  Views/        - SwiftUI views (ContentView, ModListView, etc.)
+  Views/        - SwiftUI views (ContentView, ModListView, NexusURLImportView, etc.)
 Tests/BG3MacModManagerTests/
   TestHelpers.swift            - Factory functions (makeModInfo, makeDependency, makeSEStatus)
   Version64Tests.swift         - Version64 model tests
@@ -28,6 +28,9 @@ Tests/BG3MacModManagerTests/
   ModValidationServiceTests.swift     - All 10 validation checks, topological sort
   LoadOrderImportServiceTests.swift   - BG3MM JSON & LSX import parsing
   PakReaderTests.swift                - Binary format errors, CompressionType
+  ModNotesServiceTests.swift          - Per-mod notes persistence
+  NexusURLImportServiceTests.swift    - CSV/JSON/TXT import parsing, mod matching
+  NexusAPIServiceTests.swift          - Mod ID extraction, update result logic, cache encoding
 ```
 
 ## Key Patterns
@@ -86,12 +89,12 @@ Prioritized feature and UX improvements organized by tier. Each item includes a 
 | # | Title | Scope | Status | Description | Key Files |
 |---|-------|-------|--------|-------------|-----------|
 | 3.1 | Operation History Panel | L | | Named undo stack with a History sidebar item ("Activated Mod X", "Smart Sorted", "Loaded Profile Y"). | `AppState.swift`, new `HistoryView.swift`, `ContentView.swift` |
-| 3.2 | Nexus Mods Update Detection | L | | Query Nexus API to compare installed vs. latest versions; show "Update Available" badges. Requires API key in Settings. | New `NexusAPIService.swift`, `SettingsView.swift`, `ModRowView.swift` |
+| 3.2 | Nexus Mods Update Detection | L | **Done** | Query Nexus API to compare installed vs. latest versions; show "Update Available" badges. Requires API key in Settings. | `NexusAPIService.swift`, `NexusUpdateInfo.swift`, `SettingsView.swift`, `ModRowView.swift`, `ModDetailView.swift`, `ModListView.swift`, `ContentView.swift`, `AppState.swift` |
 | 3.3 | Mod Groups / Collections | L | | User-defined named groups orthogonal to categories. Activate/deactivate/view entire groups. | New `ModGroup.swift`, new `ModGroupService.swift`, multiple views |
 | 3.4 | Conflict Resolution Advisor | L | | Analyze conflict graph and suggest compatibility patches, load order adjustments, and Nexus search links. | New `ConflictAdvisorService.swift`, `ModListView.swift`, `ModDetailView.swift` |
-| 3.5 | Comprehensive Test Suite | L | **Done** | ~120 tests across 8 test files + 1 helper: `ModInfoTests`, `DataBinaryReadingTests`, `ModCategoryTests`, `TextExportServiceTests`, `CategoryInferenceServiceTests`, `ModValidationServiceTests`, `LoadOrderImportServiceTests`, `PakReaderTests`. | `TestHelpers.swift`, multiple test files in `Tests/` |
-| 3.6 | Per-Mod User Notes | M–L | | Editable notes per mod stored in app support JSON, editable from detail panel, icon indicator in row. | New `ModNotesService.swift`, `ModDetailView.swift`, `ModRowView.swift` |
-| 3.7 | Bulk Nexus URL Import | M–L | | Import Vortex/MO2 export files to bulk-populate Nexus URLs for matching mods. | New `NexusURLImportView.swift`, `NexusURLService.swift`, `ContentView.swift` |
+| 3.5 | Comprehensive Test Suite | L | **Done** | ~150 tests across 11 test files + 1 helper: `ModInfoTests`, `DataBinaryReadingTests`, `ModCategoryTests`, `TextExportServiceTests`, `CategoryInferenceServiceTests`, `ModValidationServiceTests`, `LoadOrderImportServiceTests`, `PakReaderTests`, `ModNotesServiceTests`, `NexusURLImportServiceTests`, `NexusAPIServiceTests`. | `TestHelpers.swift`, multiple test files in `Tests/` |
+| 3.6 | Per-Mod User Notes | M–L | **Done** | Editable notes per mod stored in app support JSON, editable from detail panel, icon indicator in row. | `ModNotesService.swift`, `ModDetailView.swift`, `ModRowView.swift`, `ModListView.swift`, `AppState.swift` |
+| 3.7 | Bulk Nexus URL Import | M–L | **Done** | Import CSV/TSV/JSON/TXT files to bulk-populate Nexus URLs. Matches by UUID, exact name, or fuzzy name. | `NexusURLImportService.swift`, `NexusURLImportView.swift`, `NexusURLService.swift`, `ContentView.swift`, `AppState.swift` |
 
 ### Recommended Implementation Order
 
@@ -106,5 +109,5 @@ Items marked ~~strikethrough~~ are complete.
 7. ~~**2.3 → 2.8 → 2.5** — Inactive sorting, auto-save toggles, positional drag~~
 8. ~~**2.4 → 2.6** — PAK Inspector, advanced filters~~
 9. ~~**3.5** — Test suite (pays dividends before larger features)~~
-10. **3.6 → 3.7 → 3.2** — Per-mod notes, bulk Nexus import, update detection
+10. ~~**3.6 → 3.7 → 3.2** — Per-mod notes, bulk Nexus import, update detection~~
 11. **3.3 → 3.1 → 3.4** — Mod groups, history panel, conflict advisor

--- a/Sources/BG3MacModManager/Info.plist
+++ b/Sources/BG3MacModManager/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/BG3MacModManager/Models/NexusUpdateInfo.swift
+++ b/Sources/BG3MacModManager/Models/NexusUpdateInfo.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+/// Cached result of checking a mod's update status on Nexus Mods.
+struct NexusUpdateResult: Codable, Identifiable {
+    let modUUID: String
+    let nexusModID: Int
+    let installedVersion: String
+    let latestVersion: String
+    let latestName: String
+    let updatedDate: Date?
+    let nexusURL: String
+    let checkedDate: Date
+
+    var id: String { modUUID }
+
+    /// Whether the Nexus version differs from the installed version.
+    /// Uses simple string comparison — Nexus version strings are free-form text.
+    var hasUpdate: Bool {
+        !latestVersion.isEmpty &&
+        latestVersion.lowercased() != installedVersion.lowercased()
+    }
+}
+
+/// Cache container persisted to disk.
+struct NexusUpdateCache: Codable {
+    var results: [String: NexusUpdateResult] = [:]
+    var lastFullCheck: Date?
+}

--- a/Sources/BG3MacModManager/Services/ModNotesService.swift
+++ b/Sources/BG3MacModManager/Services/ModNotesService.swift
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+/// Persists per-mod user notes to a JSON file.
+/// Follows the same persistence pattern as NexusURLService.
+final class ModNotesService {
+
+    // MARK: - Public API
+
+    /// Get the stored note for a mod, if any.
+    func note(for modUUID: String) -> String? {
+        notes[modUUID]
+    }
+
+    /// Set or update the note for a mod. Pass nil or empty/whitespace-only string to clear.
+    func setNote(_ text: String?, for modUUID: String) {
+        if let text = text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            notes[modUUID] = text
+        } else {
+            notes.removeValue(forKey: modUUID)
+        }
+        save()
+    }
+
+    /// All stored notes (for bulk lookup / export).
+    func allNotes() -> [String: String] {
+        notes
+    }
+
+    // MARK: - Persistence
+
+    private var notes: [String: String] = [:]
+
+    private static var storageURL: URL {
+        FileLocations.appSupportDirectory.appendingPathComponent("mod_notes.json")
+    }
+
+    init() {
+        load()
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: Self.storageURL),
+              let decoded = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return
+        }
+        notes = decoded
+    }
+
+    private func save() {
+        do {
+            try FileLocations.ensureDirectoryExists(FileLocations.appSupportDirectory)
+            let data = try JSONEncoder().encode(notes)
+            try data.write(to: Self.storageURL, options: .atomic)
+        } catch {
+            // Non-fatal: notes just won't persist
+        }
+    }
+}

--- a/Sources/BG3MacModManager/Services/NexusAPIService.swift
+++ b/Sources/BG3MacModManager/Services/NexusAPIService.swift
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+/// Interfaces with the Nexus Mods API v1 to check for mod updates.
+/// Requires a personal API key configured in Settings.
+final class NexusAPIService {
+
+    // MARK: - Types
+
+    enum APIError: Error, LocalizedError {
+        case noAPIKey
+        case invalidModID
+        case rateLimited
+        case httpError(Int)
+        case networkError(Error)
+        case decodingError(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .noAPIKey:
+                return "No Nexus Mods API key configured. Set one in Settings."
+            case .invalidModID:
+                return "Could not extract a mod ID from the Nexus URL."
+            case .rateLimited:
+                return "Nexus API rate limit reached. Try again later."
+            case .httpError(let code):
+                return "Nexus API returned HTTP \(code)."
+            case .networkError(let err):
+                return "Network error: \(err.localizedDescription)"
+            case .decodingError(let err):
+                return "Failed to parse Nexus API response: \(err.localizedDescription)"
+            }
+        }
+    }
+
+    /// Subset of fields from the Nexus Mods API /mods/{id}.json response.
+    struct NexusModResponse: Codable {
+        let name: String
+        let version: String
+        let updated_timestamp: Int?
+        let available: Bool?
+
+        var updatedDate: Date? {
+            guard let ts = updated_timestamp else { return nil }
+            return Date(timeIntervalSince1970: TimeInterval(ts))
+        }
+    }
+
+    // MARK: - Configuration
+
+    private let baseURL = "https://api.nexusmods.com/v1"
+    private let gameDomain = "baldursgate3"
+    private let session: URLSession
+
+    /// Minimum interval between API requests (to respect rate limits).
+    private let requestInterval: TimeInterval = 1.0
+
+    /// Maximum age of a cached result before re-checking (in seconds).
+    static let cacheMaxAge: TimeInterval = 3600 // 1 hour
+
+    // MARK: - Cache
+
+    private var cache: NexusUpdateCache
+
+    private static var cacheURL: URL {
+        FileLocations.appSupportDirectory.appendingPathComponent("nexus_update_cache.json")
+    }
+
+    // MARK: - Initialization
+
+    init() {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 15
+        session = URLSession(configuration: config)
+        cache = Self.loadCache()
+    }
+
+    // MARK: - Public API
+
+    /// Get the API key from UserDefaults.
+    var apiKey: String? {
+        let key = UserDefaults.standard.string(forKey: "nexusAPIKey")
+        return (key?.isEmpty == false) ? key : nil
+    }
+
+    /// Check for updates for all mods that have Nexus URLs.
+    /// Returns a dictionary of UUID -> NexusUpdateResult.
+    func checkForUpdates(
+        mods: [ModInfo],
+        nexusURLService: NexusURLService,
+        progress: @escaping (Int, Int) -> Void
+    ) async throws -> [String: NexusUpdateResult] {
+        guard let apiKey = apiKey else { throw APIError.noAPIKey }
+
+        let modsWithURLs = mods.compactMap { mod -> (ModInfo, String, Int)? in
+            guard let urlString = nexusURLService.url(for: mod.uuid),
+                  let modID = extractModID(from: urlString) else {
+                return nil
+            }
+            return (mod, urlString, modID)
+        }
+
+        var results: [String: NexusUpdateResult] = cache.results
+        let total = modsWithURLs.count
+        var checked = 0
+
+        for (mod, urlString, modID) in modsWithURLs {
+            // Skip if recently checked
+            if let cached = cache.results[mod.uuid],
+               Date().timeIntervalSince(cached.checkedDate) < Self.cacheMaxAge {
+                checked += 1
+                progress(checked, total)
+                continue
+            }
+
+            // Rate limiting: wait between requests
+            if checked > 0 {
+                try await Task.sleep(nanoseconds: UInt64(requestInterval * 1_000_000_000))
+            }
+
+            do {
+                let response = try await fetchModInfo(modID: modID, apiKey: apiKey)
+                let result = NexusUpdateResult(
+                    modUUID: mod.uuid,
+                    nexusModID: modID,
+                    installedVersion: mod.version.description,
+                    latestVersion: response.version,
+                    latestName: response.name,
+                    updatedDate: response.updatedDate,
+                    nexusURL: urlString,
+                    checkedDate: Date()
+                )
+                results[mod.uuid] = result
+            } catch APIError.rateLimited {
+                // Stop checking on rate limit
+                break
+            } catch {
+                // Log but continue with other mods
+            }
+
+            checked += 1
+            progress(checked, total)
+        }
+
+        cache.results = results
+        cache.lastFullCheck = Date()
+        saveCache()
+
+        return results
+    }
+
+    /// Get cached result for a specific mod.
+    func cachedResult(for modUUID: String) -> NexusUpdateResult? {
+        cache.results[modUUID]
+    }
+
+    /// Clear all cached update data.
+    func clearCache() {
+        cache = NexusUpdateCache()
+        saveCache()
+    }
+
+    // MARK: - API Calls
+
+    private func fetchModInfo(modID: Int, apiKey: String) async throws -> NexusModResponse {
+        guard let url = URL(string: "\(baseURL)/games/\(gameDomain)/mods/\(modID).json") else {
+            throw APIError.invalidModID
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(apiKey, forHTTPHeaderField: "apikey")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw APIError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.httpError(0)
+        }
+
+        if httpResponse.statusCode == 429 {
+            throw APIError.rateLimited
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw APIError.httpError(httpResponse.statusCode)
+        }
+
+        do {
+            return try JSONDecoder().decode(NexusModResponse.self, from: data)
+        } catch {
+            throw APIError.decodingError(error)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Extract numeric mod ID from Nexus URL.
+    func extractModID(from url: String) -> Int? {
+        let pattern = #"/mods/(\d+)"#
+        guard let range = url.range(of: pattern, options: .regularExpression) else { return nil }
+        let matched = url[range]
+        guard let numRange = matched.range(of: #"\d+"#, options: .regularExpression) else { return nil }
+        return Int(matched[numRange])
+    }
+
+    // MARK: - Cache Persistence
+
+    private static func loadCache() -> NexusUpdateCache {
+        guard let data = try? Data(contentsOf: cacheURL) else {
+            return NexusUpdateCache()
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let decoded = try? decoder.decode(NexusUpdateCache.self, from: data) else {
+            return NexusUpdateCache()
+        }
+        return decoded
+    }
+
+    private func saveCache() {
+        do {
+            try FileLocations.ensureDirectoryExists(FileLocations.appSupportDirectory)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(cache)
+            try data.write(to: Self.cacheURL, options: .atomic)
+        } catch {
+            // Non-fatal: cache just won't persist
+        }
+    }
+}

--- a/Sources/BG3MacModManager/Services/NexusURLImportService.swift
+++ b/Sources/BG3MacModManager/Services/NexusURLImportService.swift
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+/// Parses external files containing mod-to-Nexus-URL mappings and matches
+/// them against installed mods for bulk URL population.
+final class NexusURLImportService {
+
+    // MARK: - Types
+
+    enum ImportFormat: String {
+        case csv = "CSV"
+        case tsv = "TSV"
+        case json = "JSON"
+        case text = "Plain Text"
+    }
+
+    enum ImportError: Error, LocalizedError {
+        case invalidJSON(String)
+        case unknownFormat(String)
+        case emptyFile
+        case noValidEntries
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidJSON(let msg): return "Invalid JSON: \(msg)"
+            case .unknownFormat(let ext): return "Unrecognized file format: .\(ext)"
+            case .emptyFile: return "The imported file is empty"
+            case .noValidEntries: return "No valid Nexus Mods URLs found in the file"
+            }
+        }
+    }
+
+    /// A single parsed entry from the import file.
+    struct ParsedEntry {
+        let identifier: String  // mod name, UUID, or empty
+        let nexusURL: String
+        let nexusModID: String? // extracted mod ID from URL
+    }
+
+    /// A match between a parsed entry and an installed mod.
+    struct MatchedEntry: Identifiable {
+        let id = UUID()
+        let parsedEntry: ParsedEntry
+        let matchedMod: ModInfo
+        let matchType: MatchType
+    }
+
+    enum MatchType: String {
+        case uuid = "UUID"
+        case exactName = "Exact Name"
+        case fuzzyName = "Fuzzy Name"
+    }
+
+    /// Result of a bulk URL import operation.
+    struct ImportResult {
+        let format: ImportFormat
+        let totalParsed: Int
+        let matched: [MatchedEntry]
+        let unmatched: [ParsedEntry]
+    }
+
+    // MARK: - Public API
+
+    /// Parse a file and match entries against installed mods.
+    func parseAndMatch(
+        fileURL: URL,
+        installedMods: [ModInfo]
+    ) throws -> ImportResult {
+        let ext = fileURL.pathExtension.lowercased()
+        let entries: [ParsedEntry]
+        let format: ImportFormat
+
+        switch ext {
+        case "csv":
+            entries = try parseCSV(at: fileURL, separator: ",")
+            format = .csv
+        case "tsv":
+            entries = try parseCSV(at: fileURL, separator: "\t")
+            format = .tsv
+        case "json":
+            entries = try parseJSON(at: fileURL)
+            format = .json
+        case "txt":
+            entries = try parsePlainText(at: fileURL)
+            format = .text
+        default:
+            throw ImportError.unknownFormat(ext)
+        }
+
+        guard !entries.isEmpty else { throw ImportError.noValidEntries }
+
+        return matchEntries(entries, against: installedMods, format: format)
+    }
+
+    /// Parse content from a string (for testing without file I/O).
+    func parseAndMatch(
+        content: String,
+        format: ImportFormat,
+        installedMods: [ModInfo]
+    ) throws -> ImportResult {
+        let entries: [ParsedEntry]
+
+        switch format {
+        case .csv:
+            entries = parseCSVContent(content, separator: ",")
+        case .tsv:
+            entries = parseCSVContent(content, separator: "\t")
+        case .json:
+            entries = try parseJSONContent(content)
+        case .text:
+            entries = parsePlainTextContent(content)
+        }
+
+        guard !entries.isEmpty else { throw ImportError.noValidEntries }
+
+        return matchEntries(entries, against: installedMods, format: format)
+    }
+
+    // MARK: - CSV/TSV Parsing
+
+    private func parseCSV(at url: URL, separator: Character) throws -> [ParsedEntry] {
+        let content = try String(contentsOf: url, encoding: .utf8)
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ImportError.emptyFile
+        }
+        return parseCSVContent(content, separator: separator)
+    }
+
+    func parseCSVContent(_ content: String, separator: Character) -> [ParsedEntry] {
+        let lines = content.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        guard !lines.isEmpty else { return [] }
+
+        var entries: [ParsedEntry] = []
+        let startIndex = looksLikeHeader(lines[0]) ? 1 : 0
+
+        for line in lines[startIndex...] {
+            let fields = line.split(separator: separator, omittingEmptySubsequences: false)
+                .map { String($0).trimmingCharacters(in: .whitespaces) }
+
+            if fields.count >= 2 {
+                // Two-column: identifier + URL
+                let identifier = fields[0]
+                let url = fields[1]
+                if isNexusURL(url) {
+                    entries.append(ParsedEntry(
+                        identifier: identifier,
+                        nexusURL: url,
+                        nexusModID: extractModID(from: url)
+                    ))
+                } else if isNexusURL(identifier) {
+                    // Reversed columns: URL first, then identifier
+                    entries.append(ParsedEntry(
+                        identifier: url,
+                        nexusURL: identifier,
+                        nexusModID: extractModID(from: identifier)
+                    ))
+                }
+            } else if fields.count == 1 && isNexusURL(fields[0]) {
+                // Single column: just URLs
+                entries.append(ParsedEntry(
+                    identifier: "",
+                    nexusURL: fields[0],
+                    nexusModID: extractModID(from: fields[0])
+                ))
+            }
+        }
+
+        return entries
+    }
+
+    // MARK: - JSON Parsing
+
+    private func parseJSON(at url: URL) throws -> [ParsedEntry] {
+        let data = try Data(contentsOf: url)
+        guard !data.isEmpty else { throw ImportError.emptyFile }
+        let content = String(data: data, encoding: .utf8) ?? ""
+        return try parseJSONContent(content)
+    }
+
+    func parseJSONContent(_ content: String) throws -> [ParsedEntry] {
+        guard let data = content.data(using: .utf8) else {
+            throw ImportError.invalidJSON("Could not read content as UTF-8")
+        }
+
+        // Try array of objects: [{"name": "...", "url": "..."}]
+        if let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
+            let entries = array.compactMap { dict -> ParsedEntry? in
+                let url = (dict["url"] as? String)
+                    ?? (dict["nexusUrl"] as? String)
+                    ?? (dict["nexus_url"] as? String)
+                    ?? (dict["nexusURL"] as? String)
+                    ?? ""
+                guard isNexusURL(url) else { return nil }
+
+                let identifier = (dict["name"] as? String)
+                    ?? (dict["modName"] as? String)
+                    ?? (dict["mod_name"] as? String)
+                    ?? (dict["uuid"] as? String)
+                    ?? (dict["UUID"] as? String)
+                    ?? ""
+
+                return ParsedEntry(
+                    identifier: identifier,
+                    nexusURL: url,
+                    nexusModID: extractModID(from: url)
+                )
+            }
+            return entries
+        }
+
+        // Try dictionary: {"uuid-or-name": "url", ...}
+        if let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
+            let entries = dict.compactMap { key, value -> ParsedEntry? in
+                guard isNexusURL(value) else { return nil }
+                return ParsedEntry(
+                    identifier: key,
+                    nexusURL: value,
+                    nexusModID: extractModID(from: value)
+                )
+            }
+            return entries
+        }
+
+        throw ImportError.invalidJSON("Expected an array of objects or a string dictionary")
+    }
+
+    // MARK: - Plain Text Parsing
+
+    private func parsePlainText(at url: URL) throws -> [ParsedEntry] {
+        let content = try String(contentsOf: url, encoding: .utf8)
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ImportError.emptyFile
+        }
+        return parsePlainTextContent(content)
+    }
+
+    func parsePlainTextContent(_ content: String) -> [ParsedEntry] {
+        content.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .compactMap { line in
+                guard isNexusURL(line) else { return nil }
+                return ParsedEntry(
+                    identifier: "",
+                    nexusURL: line,
+                    nexusModID: extractModID(from: line)
+                )
+            }
+    }
+
+    // MARK: - Matching
+
+    private func matchEntries(
+        _ entries: [ParsedEntry],
+        against mods: [ModInfo],
+        format: ImportFormat
+    ) -> ImportResult {
+        let modsByUUID = Dictionary(
+            mods.map { ($0.uuid.lowercased(), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let modsByName = Dictionary(
+            mods.map { ($0.name.lowercased(), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        var matched: [MatchedEntry] = []
+        var unmatched: [ParsedEntry] = []
+        var matchedUUIDs: Set<String> = []
+
+        for entry in entries {
+            let id = entry.identifier
+
+            // Try UUID match first
+            if !id.isEmpty, let mod = modsByUUID[id.lowercased()], !matchedUUIDs.contains(mod.uuid) {
+                matched.append(MatchedEntry(
+                    parsedEntry: entry, matchedMod: mod, matchType: .uuid
+                ))
+                matchedUUIDs.insert(mod.uuid)
+                continue
+            }
+
+            // Try exact name match
+            if !id.isEmpty, let mod = modsByName[id.lowercased()], !matchedUUIDs.contains(mod.uuid) {
+                matched.append(MatchedEntry(
+                    parsedEntry: entry, matchedMod: mod, matchType: .exactName
+                ))
+                matchedUUIDs.insert(mod.uuid)
+                continue
+            }
+
+            // Try fuzzy name match (contains, ignoring case)
+            if !id.isEmpty {
+                let lowered = id.lowercased()
+                if let mod = mods.first(where: {
+                    !matchedUUIDs.contains($0.uuid) && (
+                        $0.name.lowercased().contains(lowered) ||
+                        lowered.contains($0.name.lowercased())
+                    )
+                }) {
+                    matched.append(MatchedEntry(
+                        parsedEntry: entry, matchedMod: mod, matchType: .fuzzyName
+                    ))
+                    matchedUUIDs.insert(mod.uuid)
+                    continue
+                }
+            }
+
+            unmatched.append(entry)
+        }
+
+        return ImportResult(
+            format: format,
+            totalParsed: entries.count,
+            matched: matched,
+            unmatched: unmatched
+        )
+    }
+
+    // MARK: - Helpers
+
+    func isNexusURL(_ string: String) -> Bool {
+        string.lowercased().contains("nexusmods.com")
+    }
+
+    /// Extract mod ID from a Nexus URL like
+    /// "https://www.nexusmods.com/baldursgate3/mods/12345"
+    func extractModID(from url: String) -> String? {
+        let pattern = #"/mods/(\d+)"#
+        guard let range = url.range(of: pattern, options: .regularExpression) else {
+            return nil
+        }
+        let matched = url[range]
+        guard let numRange = matched.range(of: #"\d+"#, options: .regularExpression) else {
+            return nil
+        }
+        return String(url[numRange])
+    }
+
+    private func looksLikeHeader(_ line: String) -> Bool {
+        let lowered = line.lowercased()
+        return lowered.contains("name") || lowered.contains("url") ||
+               lowered.contains("uuid") || lowered.contains("mod")
+    }
+}

--- a/Sources/BG3MacModManager/Services/NexusURLService.swift
+++ b/Sources/BG3MacModManager/Services/NexusURLService.swift
@@ -28,6 +28,19 @@ final class NexusURLService {
         urls
     }
 
+    /// Set multiple URLs at once (for bulk import operations).
+    /// Each key is a mod UUID, each value is the Nexus URL.
+    func bulkSetURLs(_ newURLs: [String: String]) {
+        for (uuid, url) in newURLs {
+            if url.isEmpty {
+                urls.removeValue(forKey: uuid)
+            } else {
+                urls[uuid] = url
+            }
+        }
+        save()
+    }
+
     // MARK: - Persistence
 
     private var urls: [String: String] = [:]

--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -235,6 +235,13 @@ struct ContentView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            if appState.isCheckingForUpdates {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Checking updates (\(appState.updateCheckProgress.checked)/\(appState.updateCheckProgress.total))...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
             Text(appState.statusMessage)
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -340,6 +347,7 @@ struct ToolsContainerView: View {
     enum Tool: String, CaseIterable {
         case versionGenerator = "Version Generator"
         case pakInspector = "PAK Inspector"
+        case nexusURLImport = "Nexus URL Import"
     }
 
     @State private var selectedTool: Tool = .versionGenerator
@@ -363,6 +371,8 @@ struct ToolsContainerView: View {
                 VersionGeneratorView()
             case .pakInspector:
                 PakInspectorView()
+            case .nexusURLImport:
+                NexusURLImportView()
             }
         }
     }

--- a/Sources/BG3MacModManager/Views/ModListView.swift
+++ b/Sources/BG3MacModManager/Views/ModListView.swift
@@ -135,6 +135,23 @@ struct ModListView: View {
             .disabled(appState.isLoading)
             .help("Rescan mods folder")
 
+            Button {
+                Task { await appState.checkForNexusUpdates() }
+            } label: {
+                if appState.isCheckingForUpdates {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label("Check Updates", systemImage: "arrow.triangle.2.circlepath")
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+            .disabled(appState.isCheckingForUpdates || appState.nexusAPIService.apiKey == nil)
+            .help(appState.nexusAPIService.apiKey == nil
+                ? "Set a Nexus Mods API key in Settings to enable update checking"
+                : "Check Nexus Mods for available updates")
+
             Spacer()
 
             Button {
@@ -444,6 +461,10 @@ struct ModListView: View {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(mod.uuid, forType: .string)
                             }
+                            Button(appState.modNotesService.note(for: mod.uuid) != nil ? "Edit Note" : "Add Note") {
+                                appState.selectedModID = mod.uuid
+                            }
+                            .help("Add or edit a personal note for this mod")
                             if let filePath = mod.pakFilePath {
                                 Divider()
                                 Button("Reveal in Finder") {
@@ -534,6 +555,10 @@ struct ModListView: View {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(mod.uuid, forType: .string)
                             }
+                            Button(appState.modNotesService.note(for: mod.uuid) != nil ? "Edit Note" : "Add Note") {
+                                appState.selectedModID = mod.uuid
+                            }
+                            .help("Add or edit a personal note for this mod")
                             if let filePath = mod.pakFilePath {
                                 Divider()
                                 Button("Reveal in Finder") {

--- a/Sources/BG3MacModManager/Views/ModRowView.swift
+++ b/Sources/BG3MacModManager/Views/ModRowView.swift
@@ -36,6 +36,21 @@ struct ModRowView: View {
                             .help(category.tooltip)
                     }
 
+                    if appState.hasNexusUpdate(for: mod) {
+                        Text("Update")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.yellow, in: RoundedRectangle(cornerRadius: 3))
+                            .help({
+                                if let info = appState.nexusUpdateInfo(for: mod) {
+                                    return "Update available: v\(info.latestVersion) (installed: v\(info.installedVersion))"
+                                }
+                                return "A newer version is available on Nexus Mods"
+                            }())
+                    }
+
                     if mod.requiresScriptExtender {
                         Text("SE")
                             .font(.caption2.bold())
@@ -76,6 +91,14 @@ struct ModRowView: View {
             }
 
             Spacer()
+
+            // Note indicator
+            if appState.modNotesService.note(for: mod.uuid) != nil {
+                Image(systemName: "note.text")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .help("This mod has user notes")
+            }
 
             // Inline dependency status indicator (for active mods with dependencies)
             if isActive && !mod.dependencies.isEmpty && !mod.isBasicGameModule {

--- a/Sources/BG3MacModManager/Views/NexusURLImportView.swift
+++ b/Sources/BG3MacModManager/Views/NexusURLImportView.swift
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// View for bulk-importing Nexus URLs from CSV, TSV, JSON, or plain text files.
+struct NexusURLImportView: View {
+    @EnvironmentObject var appState: AppState
+
+    @State private var importResult: NexusURLImportService.ImportResult?
+    @State private var errorText: String?
+    @State private var isApplied = false
+    @State private var selectedFileName: String?
+
+    private let importService = NexusURLImportService()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header bar
+            HStack {
+                Text("Bulk Nexus URL Import")
+                    .font(.headline)
+                Spacer()
+                if let fileName = selectedFileName {
+                    Text(fileName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Button("Select File...") {
+                    selectFile()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .help("Choose a CSV, TSV, JSON, or TXT file with mod names and Nexus URLs")
+            }
+            .padding()
+
+            Divider()
+
+            if let result = importResult {
+                resultView(result)
+            } else if let error = errorText {
+                Spacer()
+                VStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 36))
+                        .foregroundStyle(.red)
+                    Text(error)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            } else {
+                emptyStateView
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "link.badge.plus")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text("Import Nexus Mods URLs in Bulk")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Supported formats:")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+
+                Group {
+                    Label("CSV/TSV — Two columns: mod name, Nexus URL", systemImage: "tablecells")
+                    Label("JSON — Array of objects or UUID-to-URL dictionary", systemImage: "curlybraces")
+                    Label("TXT — One Nexus URL per line", systemImage: "doc.plaintext")
+                }
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            }
+            .frame(maxWidth: 400)
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Result View
+
+    private func resultView(_ result: NexusURLImportService.ImportResult) -> some View {
+        VStack(spacing: 0) {
+            // Stats bar
+            HStack(spacing: 16) {
+                statBox("Parsed", count: result.totalParsed, color: .secondary)
+                statBox("Matched", count: result.matched.count, color: .green)
+                statBox("Unmatched", count: result.unmatched.count,
+                         color: result.unmatched.isEmpty ? .secondary : .orange)
+                Spacer()
+                if !isApplied && !result.matched.isEmpty {
+                    Button("Apply \(result.matched.count) URL(s)") {
+                        applyMatches(result)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                    .help("Set Nexus URLs for all matched mods")
+                } else if isApplied {
+                    Label("Applied", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                }
+            }
+            .padding()
+
+            Divider()
+
+            // Matched entries
+            List {
+                if !result.matched.isEmpty {
+                    Section("Matched Mods (\(result.matched.count))") {
+                        ForEach(result.matched) { entry in
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(entry.matchedMod.name)
+                                        .font(.body)
+                                    Text(entry.parsedEntry.nexusURL)
+                                        .font(.caption)
+                                        .foregroundStyle(.blue)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                }
+                                Spacer()
+                                Text(entry.matchType.rawValue)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(Color.secondary.opacity(0.15), in: RoundedRectangle(cornerRadius: 3))
+                            }
+                        }
+                    }
+                }
+
+                if !result.unmatched.isEmpty {
+                    Section("Unmatched Entries (\(result.unmatched.count))") {
+                        ForEach(Array(result.unmatched.enumerated()), id: \.offset) { _, entry in
+                            VStack(alignment: .leading, spacing: 2) {
+                                if !entry.identifier.isEmpty {
+                                    Text(entry.identifier)
+                                        .font(.body)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Text(entry.nexusURL)
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                }
+            }
+            .listStyle(.inset(alternatesRowBackgrounds: true))
+        }
+    }
+
+    private func statBox(_ label: String, count: Int, color: Color) -> some View {
+        VStack(spacing: 2) {
+            Text("\(count)")
+                .font(.title3.bold().monospacedDigit())
+                .foregroundStyle(color)
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func selectFile() {
+        let panel = NSOpenPanel()
+        panel.title = "Select Nexus URL Import File"
+        panel.allowedContentTypes = [
+            UTType.commaSeparatedText,
+            UTType.tabSeparatedText,
+            UTType.json,
+            UTType.plainText
+        ]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        selectedFileName = url.lastPathComponent
+        importResult = nil
+        errorText = nil
+        isApplied = false
+
+        do {
+            let allMods = appState.activeMods + appState.inactiveMods
+            importResult = try importService.parseAndMatch(
+                fileURL: url,
+                installedMods: allMods
+            )
+        } catch {
+            errorText = error.localizedDescription
+        }
+    }
+
+    private func applyMatches(_ result: NexusURLImportService.ImportResult) {
+        var urls: [String: String] = [:]
+        for entry in result.matched {
+            urls[entry.matchedMod.uuid] = entry.parsedEntry.nexusURL
+        }
+        appState.bulkSetNexusURLs(urls)
+        isApplied = true
+    }
+}

--- a/Sources/BG3MacModManager/Views/SettingsView.swift
+++ b/Sources/BG3MacModManager/Views/SettingsView.swift
@@ -10,6 +10,8 @@ struct SettingsView: View {
     @AppStorage("backupRetentionDays") var backupRetentionDays = 30
     @AppStorage("autoSaveBeforeLaunch") var autoSaveBeforeLaunch = false
     @AppStorage("autoSaveOnProfileLoad") var autoSaveOnProfileLoad = false
+    @AppStorage("nexusAPIKey") var nexusAPIKey = ""
+    @AppStorage("autoCheckNexusUpdates") var autoCheckNexusUpdates = false
 
     var body: some View {
         TabView {
@@ -22,7 +24,7 @@ struct SettingsView: View {
             seSettings
                 .tabItem { Label("Script Extender", systemImage: "terminal") }
         }
-        .frame(width: 500, height: 350)
+        .frame(width: 500, height: 420)
         .padding()
     }
 
@@ -73,6 +75,34 @@ struct SettingsView: View {
                             ? "Baldur's Gate 3 detected via Steam"
                             : "Baldur's Gate 3 not found — check that it's installed via Steam")
                 }
+            }
+
+            Section("Nexus Mods") {
+                SecureField("API Key", text: $nexusAPIKey)
+                    .help("Your personal Nexus Mods API key for checking mod updates")
+
+                if nexusAPIKey.isEmpty {
+                    HStack(spacing: 4) {
+                        Image(systemName: "info.circle")
+                            .foregroundStyle(.blue)
+                        Text("An API key is required to check for mod updates.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Button("Get API Key from Nexus Mods") {
+                        if let url = URL(string: "https://www.nexusmods.com/users/myaccount?tab=api+access") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .help("Opens your Nexus Mods account page where you can generate a personal API key")
+                }
+
+                Toggle("Check for updates on app launch", isOn: $autoCheckNexusUpdates)
+                    .help("Automatically check Nexus Mods for updates when the app starts. Requires an API key and Nexus URLs set on your mods.")
+                    .disabled(nexusAPIKey.isEmpty)
             }
         }
     }

--- a/Tests/BG3MacModManagerTests/ModNotesServiceTests.swift
+++ b/Tests/BG3MacModManagerTests/ModNotesServiceTests.swift
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class ModNotesServiceTests: XCTestCase {
+
+    var service: ModNotesService!
+
+    override func setUp() {
+        super.setUp()
+        service = ModNotesService()
+    }
+
+    func testNoteForUnknownUUIDReturnsNil() {
+        XCTAssertNil(service.note(for: "nonexistent-uuid"))
+    }
+
+    func testSetAndGetNote() {
+        service.setNote("Test note", for: "test-uuid")
+        XCTAssertEqual(service.note(for: "test-uuid"), "Test note")
+    }
+
+    func testSetNilClearsNote() {
+        service.setNote("Test note", for: "test-uuid")
+        service.setNote(nil, for: "test-uuid")
+        XCTAssertNil(service.note(for: "test-uuid"))
+    }
+
+    func testSetEmptyStringClearsNote() {
+        service.setNote("Test note", for: "test-uuid")
+        service.setNote("", for: "test-uuid")
+        XCTAssertNil(service.note(for: "test-uuid"))
+    }
+
+    func testWhitespaceOnlyNoteIsCleared() {
+        service.setNote("   \n  ", for: "test-uuid")
+        XCTAssertNil(service.note(for: "test-uuid"))
+    }
+
+    func testAllNotesReturnsAllStoredNotes() {
+        service.setNote("Note A", for: "uuid-a")
+        service.setNote("Note B", for: "uuid-b")
+        let all = service.allNotes()
+        XCTAssertEqual(all.count, 2)
+        XCTAssertEqual(all["uuid-a"], "Note A")
+        XCTAssertEqual(all["uuid-b"], "Note B")
+    }
+
+    func testOverwriteExistingNote() {
+        service.setNote("Original", for: "test-uuid")
+        service.setNote("Updated", for: "test-uuid")
+        XCTAssertEqual(service.note(for: "test-uuid"), "Updated")
+    }
+
+    func testAllNotesEmptyByDefault() {
+        XCTAssertTrue(service.allNotes().isEmpty)
+    }
+
+    func testClearOneNoteDoesNotAffectOthers() {
+        service.setNote("Note A", for: "uuid-a")
+        service.setNote("Note B", for: "uuid-b")
+        service.setNote(nil, for: "uuid-a")
+        XCTAssertNil(service.note(for: "uuid-a"))
+        XCTAssertEqual(service.note(for: "uuid-b"), "Note B")
+    }
+}

--- a/Tests/BG3MacModManagerTests/NexusAPIServiceTests.swift
+++ b/Tests/BG3MacModManagerTests/NexusAPIServiceTests.swift
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class NexusAPIServiceTests: XCTestCase {
+
+    var service: NexusAPIService!
+
+    override func setUp() {
+        super.setUp()
+        service = NexusAPIService()
+    }
+
+    // MARK: - Extract Mod ID
+
+    func testExtractModIDFromStandardURL() {
+        XCTAssertEqual(
+            service.extractModID(from: "https://www.nexusmods.com/baldursgate3/mods/12345"),
+            12345
+        )
+    }
+
+    func testExtractModIDFromURLWithTab() {
+        XCTAssertEqual(
+            service.extractModID(from: "https://www.nexusmods.com/baldursgate3/mods/9999?tab=files"),
+            9999
+        )
+    }
+
+    func testExtractModIDFromURLWithTrailingSlash() {
+        XCTAssertEqual(
+            service.extractModID(from: "https://www.nexusmods.com/baldursgate3/mods/42/"),
+            42
+        )
+    }
+
+    func testExtractModIDFromInvalidURL() {
+        XCTAssertNil(service.extractModID(from: "https://www.google.com"))
+    }
+
+    func testExtractModIDFromEmptyString() {
+        XCTAssertNil(service.extractModID(from: ""))
+    }
+
+    func testExtractModIDFromURLWithoutNumber() {
+        XCTAssertNil(service.extractModID(from: "https://www.nexusmods.com/baldursgate3/mods/"))
+    }
+
+    // MARK: - NexusUpdateResult.hasUpdate
+
+    func testHasUpdateWhenVersionsDiffer() {
+        let result = NexusUpdateResult(
+            modUUID: "test", nexusModID: 1,
+            installedVersion: "1.0.0", latestVersion: "1.1.0",
+            latestName: "Test Mod", updatedDate: nil,
+            nexusURL: "https://www.nexusmods.com/baldursgate3/mods/1",
+            checkedDate: Date()
+        )
+        XCTAssertTrue(result.hasUpdate)
+    }
+
+    func testNoUpdateWhenVersionsMatch() {
+        let result = NexusUpdateResult(
+            modUUID: "test", nexusModID: 1,
+            installedVersion: "1.0.0", latestVersion: "1.0.0",
+            latestName: "Test Mod", updatedDate: nil,
+            nexusURL: "https://www.nexusmods.com/baldursgate3/mods/1",
+            checkedDate: Date()
+        )
+        XCTAssertFalse(result.hasUpdate)
+    }
+
+    func testCaseInsensitiveVersionMatch() {
+        let result = NexusUpdateResult(
+            modUUID: "test", nexusModID: 1,
+            installedVersion: "V1.0", latestVersion: "v1.0",
+            latestName: "Test Mod", updatedDate: nil,
+            nexusURL: "https://www.nexusmods.com/baldursgate3/mods/1",
+            checkedDate: Date()
+        )
+        XCTAssertFalse(result.hasUpdate)
+    }
+
+    func testNoUpdateWhenLatestVersionEmpty() {
+        let result = NexusUpdateResult(
+            modUUID: "test", nexusModID: 1,
+            installedVersion: "1.0.0", latestVersion: "",
+            latestName: "Test Mod", updatedDate: nil,
+            nexusURL: "https://www.nexusmods.com/baldursgate3/mods/1",
+            checkedDate: Date()
+        )
+        XCTAssertFalse(result.hasUpdate)
+    }
+
+    func testHasUpdateWithFreeFormVersionStrings() {
+        let result = NexusUpdateResult(
+            modUUID: "test", nexusModID: 1,
+            installedVersion: "Release 4", latestVersion: "Release 5",
+            latestName: "Test Mod", updatedDate: nil,
+            nexusURL: "https://www.nexusmods.com/baldursgate3/mods/1",
+            checkedDate: Date()
+        )
+        XCTAssertTrue(result.hasUpdate)
+    }
+
+    // MARK: - NexusUpdateCache Codable
+
+    func testNexusUpdateCacheRoundTrip() throws {
+        let result = NexusUpdateResult(
+            modUUID: "test-uuid", nexusModID: 42,
+            installedVersion: "1.0", latestVersion: "2.0",
+            latestName: "Test", updatedDate: Date(timeIntervalSince1970: 1700000000),
+            nexusURL: "https://www.nexusmods.com/baldursgate3/mods/42",
+            checkedDate: Date(timeIntervalSince1970: 1700001000)
+        )
+        var cache = NexusUpdateCache()
+        cache.results["test-uuid"] = result
+        cache.lastFullCheck = Date(timeIntervalSince1970: 1700001000)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(cache)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(NexusUpdateCache.self, from: data)
+
+        XCTAssertEqual(decoded.results.count, 1)
+        XCTAssertEqual(decoded.results["test-uuid"]?.latestVersion, "2.0")
+        XCTAssertNotNil(decoded.lastFullCheck)
+    }
+}

--- a/Tests/BG3MacModManagerTests/NexusURLImportServiceTests.swift
+++ b/Tests/BG3MacModManagerTests/NexusURLImportServiceTests.swift
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import XCTest
+@testable import BG3MacModManager
+
+final class NexusURLImportServiceTests: XCTestCase {
+
+    var service: NexusURLImportService!
+
+    override func setUp() {
+        super.setUp()
+        service = NexusURLImportService()
+    }
+
+    // MARK: - Extract Mod ID
+
+    func testExtractModIDFromStandardURL() {
+        XCTAssertEqual(
+            service.extractModID(from: "https://www.nexusmods.com/baldursgate3/mods/12345"),
+            "12345"
+        )
+    }
+
+    func testExtractModIDFromURLWithQueryParams() {
+        XCTAssertEqual(
+            service.extractModID(from: "https://www.nexusmods.com/baldursgate3/mods/9999?tab=files"),
+            "9999"
+        )
+    }
+
+    func testExtractModIDFromInvalidURL() {
+        XCTAssertNil(service.extractModID(from: "https://www.google.com"))
+    }
+
+    func testExtractModIDFromEmptyString() {
+        XCTAssertNil(service.extractModID(from: ""))
+    }
+
+    // MARK: - isNexusURL
+
+    func testIsNexusURLValid() {
+        XCTAssertTrue(service.isNexusURL("https://www.nexusmods.com/baldursgate3/mods/1"))
+    }
+
+    func testIsNexusURLInvalid() {
+        XCTAssertFalse(service.isNexusURL("https://www.google.com"))
+    }
+
+    func testIsNexusURLCaseInsensitive() {
+        XCTAssertTrue(service.isNexusURL("https://www.NexusMods.com/baldursgate3/mods/1"))
+    }
+
+    // MARK: - CSV Parsing
+
+    func testParseCSVTwoColumns() {
+        let csv = """
+        ModA,https://www.nexusmods.com/baldursgate3/mods/111
+        ModB,https://www.nexusmods.com/baldursgate3/mods/222
+        """
+        let entries = service.parseCSVContent(csv, separator: ",")
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].identifier, "ModA")
+        XCTAssertEqual(entries[0].nexusURL, "https://www.nexusmods.com/baldursgate3/mods/111")
+        XCTAssertEqual(entries[0].nexusModID, "111")
+    }
+
+    func testParseCSVSkipsHeader() {
+        let csv = """
+        Name,URL
+        ModA,https://www.nexusmods.com/baldursgate3/mods/111
+        """
+        let entries = service.parseCSVContent(csv, separator: ",")
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].identifier, "ModA")
+    }
+
+    func testParseCSVSingleColumnURLs() {
+        let csv = """
+        https://www.nexusmods.com/baldursgate3/mods/111
+        https://www.nexusmods.com/baldursgate3/mods/222
+        """
+        let entries = service.parseCSVContent(csv, separator: ",")
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertTrue(entries[0].identifier.isEmpty)
+    }
+
+    func testParseCSVIgnoresNonNexusURLs() {
+        let csv = """
+        ModA,https://www.google.com
+        ModB,https://www.nexusmods.com/baldursgate3/mods/222
+        """
+        let entries = service.parseCSVContent(csv, separator: ",")
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].identifier, "ModB")
+    }
+
+    // MARK: - JSON Parsing
+
+    func testParseJSONArrayFormat() throws {
+        let json = """
+        [
+            {"name": "ModA", "url": "https://www.nexusmods.com/baldursgate3/mods/111"},
+            {"name": "ModB", "url": "https://www.nexusmods.com/baldursgate3/mods/222"}
+        ]
+        """
+        let entries = try service.parseJSONContent(json)
+        XCTAssertEqual(entries.count, 2)
+    }
+
+    func testParseJSONDictionaryFormat() throws {
+        let json = """
+        {
+            "some-uuid": "https://www.nexusmods.com/baldursgate3/mods/111",
+            "other-uuid": "https://www.nexusmods.com/baldursgate3/mods/222"
+        }
+        """
+        let entries = try service.parseJSONContent(json)
+        XCTAssertEqual(entries.count, 2)
+    }
+
+    func testParseJSONInvalidThrows() {
+        XCTAssertThrowsError(try service.parseJSONContent("not json at all"))
+    }
+
+    func testParseJSONAlternativeKeys() throws {
+        let json = """
+        [{"modName": "ModA", "nexus_url": "https://www.nexusmods.com/baldursgate3/mods/111"}]
+        """
+        let entries = try service.parseJSONContent(json)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].identifier, "ModA")
+    }
+
+    // MARK: - Plain Text Parsing
+
+    func testParsePlainText() {
+        let text = """
+        https://www.nexusmods.com/baldursgate3/mods/111
+        not a url
+        https://www.nexusmods.com/baldursgate3/mods/222
+        """
+        let entries = service.parsePlainTextContent(text)
+        XCTAssertEqual(entries.count, 2)
+    }
+
+    // MARK: - Matching
+
+    func testMatchByExactName() throws {
+        let mods = [makeTestMod(uuid: "uuid-1", name: "Cool Mod")]
+        let result = try service.parseAndMatch(
+            content: "Cool Mod,https://www.nexusmods.com/baldursgate3/mods/111",
+            format: .csv,
+            installedMods: mods
+        )
+        XCTAssertEqual(result.matched.count, 1)
+        XCTAssertEqual(result.matched[0].matchType, .exactName)
+        XCTAssertEqual(result.matched[0].matchedMod.uuid, "uuid-1")
+    }
+
+    func testMatchByUUID() throws {
+        let mods = [makeTestMod(uuid: "abc-123", name: "Cool Mod")]
+        let result = try service.parseAndMatch(
+            content: "abc-123,https://www.nexusmods.com/baldursgate3/mods/111",
+            format: .csv,
+            installedMods: mods
+        )
+        XCTAssertEqual(result.matched.count, 1)
+        XCTAssertEqual(result.matched[0].matchType, .uuid)
+    }
+
+    func testMatchByFuzzyName() throws {
+        let mods = [makeTestMod(uuid: "uuid-1", name: "Cool Mod Extended")]
+        let result = try service.parseAndMatch(
+            content: "Cool Mod,https://www.nexusmods.com/baldursgate3/mods/111",
+            format: .csv,
+            installedMods: mods
+        )
+        XCTAssertEqual(result.matched.count, 1)
+        XCTAssertEqual(result.matched[0].matchType, .fuzzyName)
+    }
+
+    func testUnmatchedEntries() throws {
+        let mods = [makeTestMod(uuid: "uuid-1", name: "Cool Mod")]
+        let result = try service.parseAndMatch(
+            content: "Unknown Mod,https://www.nexusmods.com/baldursgate3/mods/111",
+            format: .csv,
+            installedMods: mods
+        )
+        XCTAssertEqual(result.matched.count, 0)
+        XCTAssertEqual(result.unmatched.count, 1)
+    }
+
+    func testNoValidEntriesThrows() {
+        XCTAssertThrowsError(try service.parseAndMatch(
+            content: "no nexus urls here",
+            format: .text,
+            installedMods: []
+        ))
+    }
+
+    // MARK: - Helpers
+
+    private func makeTestMod(uuid: String, name: String) -> ModInfo {
+        makeModInfo(uuid: uuid, name: name)
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive Nexus Mods integration to the mod manager, enabling users to bulk-import Nexus URLs from external files, check for mod updates via the Nexus API, and attach personal notes to mods.

## Key Changes

### Nexus URL Bulk Import
- **NexusURLImportService**: New service that parses mod-to-URL mappings from CSV, TSV, JSON, and plain text files
  - Supports flexible CSV/TSV formats (identifier + URL, reversed columns, or URLs only)
  - Handles multiple JSON formats (array of objects or UUID-to-URL dictionary)
  - Matches parsed entries against installed mods by UUID, exact name, or fuzzy name matching
  - Comprehensive test coverage with 15+ test cases
- **NexusURLImportView**: New UI for selecting files and previewing matched/unmatched entries before applying
- **NexusURLService.bulkSetURLs()**: New method to set multiple URLs at once

### Nexus Mods API Integration
- **NexusAPIService**: New service for checking mod updates via Nexus Mods API v1
  - Requires personal API key (configured in Settings)
  - Fetches latest version, name, and update date for mods with Nexus URLs
  - Implements rate limiting (1 second between requests) and caching (1 hour TTL)
  - Persists cache to disk to minimize API calls
  - Comprehensive error handling with user-friendly messages
- **NexusUpdateResult**: New model for storing cached update check results
- **AppState.checkForNexusUpdates()**: New async method to check all mods with Nexus URLs
- **ModListView**: Added "Check Updates" button to trigger manual update checks
- **ModRowView**: Added yellow "Update" badge for mods with available updates
- **ModDetailView**: Added update status display with link to Nexus page

### Mod Notes
- **ModNotesService**: New service for persisting per-mod user notes to JSON
  - Simple key-value storage (UUID → note text)
  - Automatic persistence to disk
- **ModDetailView.notesSection**: New UI for viewing and editing mod notes
- **AppState.modNotesService**: Integrated into app state for easy access

### Settings & Auto-Check
- **SettingsView**: Added Nexus API key input field and "Auto-check for updates" toggle
- **AppState**: Auto-checks for updates on app launch if enabled and API key is configured
- **AppState.copyModInfo()**: Updated to include notes in copied text

### Version Bump
- Updated to v1.1.0 in Info.plist and CLAUDE.md

## Implementation Details

- All new services follow the existing persistence pattern (JSON files in app support directory)
- Update checking is async and shows progress in the UI
- Fuzzy name matching uses substring containment (case-insensitive) for flexible mod identification
- Version comparison is case-insensitive string matching (Nexus uses free-form version strings)
- Comprehensive test suites added for all new services (NexusURLImportServiceTests, NexusAPIServiceTests, ModNotesServiceTests)

https://claude.ai/code/session_01KQ7rKW2u7tBatx3gYZMHpn