### PR TITLE
Add ZIP file support to PAK Inspector with multi-PAK selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Tests/BG3MacModManagerTests/
 - **Button styles**: `.borderedProminent` for primary actions, `.bordered` for secondary, `.plain` for icon-only
 - **Toolbar**: Standard macOS toolbar in ContentView; in-content action bars in views like ModListView for prominent buttons
 - **All buttons** should have `.help()` tooltips
+- **Help & tooltips**: Any changes or new features must update `HelpView.swift` documentation and ensure all new buttons/controls have `.help()` tooltips
 - **State**: Single `AppState` (ObservableObject) passed via `.environmentObject()`
 - **Async**: Use `Task { await ... }` in button actions for async AppState methods
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-BG3 Mac Mod Manager is a macOS SwiftUI application for managing Baldur's Gate 3 mods. It uses Swift Package Manager (SPM) with swift-tools-version 5.9, targeting macOS 13+. Current release: **v1.1.0**.
+BG3 Mac Mod Manager is a macOS SwiftUI application for managing Baldur's Gate 3 mods. It uses Swift Package Manager (SPM) with swift-tools-version 5.9, targeting macOS 13+. Current release: **v1.2.0**.
 
 ## Build Environment
 
@@ -76,7 +76,7 @@ Prioritized feature and UX improvements organized by tier. Each item includes a 
 | 2.1 | Undo/Redo for Load Order | M | **Done** | Snapshot `(activeMods, inactiveMods)` before each mutation; support Cmd+Z / Cmd+Shift+Z. | `AppState.swift`, `BG3MacModManagerApp.swift` |
 | 2.2 | Profile Load Missing Mods Report | M | **Done** | When loading a profile, show a summary dialog of matched vs. missing mods with Nexus URLs. Reuse `ImportSummaryView`. | `AppState.swift`, `ContentView.swift`, `ImportSummaryView.swift` |
 | 2.3 | Inactive Mods Sorting Options | S–M | **Done** | Sort picker for inactive section: by name, author, category, file date, or file size. Persistent via @AppStorage. | `ModListView.swift` |
-| 2.4 | PAK Inspector Tool | M | **Done** | New tool under "Tools" sidebar to inspect any PAK file's internal listing, meta.lsx, and info.json. Uses existing `PakReader`. | `PakInspectorView.swift`, `ContentView.swift`, `PakReader.swift` |
+| 2.4 | PAK Inspector Tool | M | **Done** | New tool under "Tools" sidebar to inspect any PAK or ZIP file's internal listing, meta.lsx, and info.json. Accepts ZIP archives containing PAKs with multi-PAK picker and ZIP-level info.json viewing. Uses existing `PakReader` and `ArchiveService`. | `PakInspectorView.swift`, `ContentView.swift`, `PakReader.swift` |
 | 2.5 | Positional Drag from Inactive to Active | M | **Done** | Dragging an inactive mod into the active list inserts at the drop position via `.onInsert`. Falls back to append when filters are active. | `ModListView.swift`, `AppState.swift` |
 | 2.6 | Advanced Filter Popover | M | **Done** | Filter button in category bar with popover for: SE required, has warnings, metadata source. Badge shows active filter count. | `ModListView.swift` |
 | 2.7 | Profile Renaming and Updating | M | **Done** | "Rename" and "Update" (overwrite with current load order) actions on profile rows. | `ProfileManagerView.swift`, `ProfileService.swift`, `AppState.swift` |

--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -133,6 +133,7 @@ struct BG3MacModManagerApp: App {
         ]
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
+        panel.treatsFilePackagesAsDirectories = false
 
         if panel.runModal() == .OK, !panel.urls.isEmpty {
             Task {

--- a/Sources/BG3MacModManager/Info.plist
+++ b/Sources/BG3MacModManager/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/BG3MacModManager/Views/HelpView.swift
+++ b/Sources/BG3MacModManager/Views/HelpView.swift
@@ -138,7 +138,7 @@ struct HelpView: View {
                 "Profiles — Save and load named mod configurations",
                 "Backups — View and restore modsettings.lsx backups",
                 "Script Extender — Check bg3se-macos installation status",
-                "Tools — Version number converter and PAK file inspector",
+                "Tools — Version number converter and PAK/ZIP file inspector",
                 "Help — This documentation",
             ])
         }
@@ -454,14 +454,14 @@ struct HelpView: View {
             helpHeading("Importing Mods")
             helpText("There are several ways to import mod files:")
             helpBulletList([
-                "File > Import Mod (Cmd+I) — Opens a file picker for .pak, .zip, .tar, and other archive formats",
+                "File > Import Mod (Cmd+I) — Opens a file picker for .pak, .zip, .tar, and other archive formats. You can select a ZIP file directly without needing to open it first.",
                 "Drag and drop — Drag mod files directly onto the app window from Finder",
                 "Manual — Place .pak files directly in the Mods folder and click Refresh",
             ])
             helpText("""
-            When importing archives (.zip, .tar, etc.), the app extracts all .pak files and \
-            their companion info.json files into the Mods folder. After import, you are prompted \
-            to activate the newly imported mods.
+            When importing archives (.zip, .tar, etc.), the app automatically extracts all .pak \
+            files and their companion info.json files into the Mods folder. After import, you are \
+            prompted to activate the newly imported mods.
             """)
 
             helpHeading("Importing Load Orders")
@@ -645,8 +645,8 @@ struct HelpView: View {
 
             helpHeading("PAK Inspector")
             helpText("""
-            The PAK Inspector lets you open any .pak (LSPK v18) archive and examine its contents \
-            without extracting the entire file. Use it to:
+            The PAK Inspector lets you open any .pak (LSPK v18) archive or .zip file containing \
+            a PAK and examine its contents without extracting the entire file. Use it to:
             """)
             helpBulletList([
                 "View archive header information (version, flags, priority, solid compression status)",
@@ -656,6 +656,12 @@ struct HelpView: View {
                 "Search/filter the file list by name",
                 "Copy file paths from within the archive",
             ])
+            helpText("""
+            You can open ZIP files directly — the inspector will extract the PAK inside \
+            automatically. If a ZIP contains multiple PAK files, you will be prompted to choose \
+            which one to inspect. Any info.json found alongside the PAK in the ZIP is available \
+            via the \"View info.json (ZIP)\" quick action button.
+            """)
             helpText("""
             Right-click any file in the list to view its contents or copy its path. This is useful \
             for debugging mod issues, verifying mod contents, or inspecting unfamiliar PAK files.


### PR DESCRIPTION
## Summary
Enhanced the PAK Inspector tool to support opening ZIP archives directly, with automatic extraction and intelligent handling of multiple PAK files within a single archive.

## Key Changes

- **ZIP file support**: PAK Inspector now accepts both `.pak` and `.zip` files via the file picker
- **Automatic extraction**: ZIP files are extracted to a temporary directory that is cleaned up on view disappear or when loading a new file
- **Multi-PAK handling**: When a ZIP contains multiple PAK files, a sheet picker is displayed allowing users to select which PAK to inspect
- **ZIP-level metadata**: Detects and displays `info.json` files found alongside PAKs in the ZIP archive via a new "View info.json (ZIP)" quick action button
- **File picker migration**: Replaced SwiftUI's `.fileImporter` with `NSOpenPanel` to support both file types and provide better control over file package handling
- **UI improvements**: 
  - Updated button labels and help text to reflect PAK/ZIP support
  - Enhanced file selection bar to show both source file (ZIP) and active PAK file when applicable
  - Added proper state management for temporary directories and extracted PAK URLs

## Implementation Details

- New state variables track: `sourceURL` (original user selection), `tempExtractionDir` (cleanup target), `zipInfoJsonContent` (ZIP-level metadata), and PAK picker state
- `loadZip()` recursively searches extracted contents for all `.pak` files and the first `info.json`
- `cleanupTempDir()` ensures temporary extraction directories are removed to prevent disk space leaks
- Updated help documentation in `HelpView.swift` to explain ZIP support and the new workflow
- Version bumped to v1.2.0
- All new UI controls include `.help()` tooltips per project guidelines

https://claude.ai/code/session_011QypR5H1Szq2onDBmvDiFt