### PR TITLE
Fix file picker ZIP navigation with Select/Browse/Import buttons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ Tests/BG3MacModManagerTests/
 
 ## Workflow
 
+**Ask clarifying questions when uncertain.** If a prompt is ambiguous, has multiple possible interpretations, or you're unsure about the intended UX or behavior, ask the user before implementing. It is always better to clarify upfront than to implement the wrong thing and iterate.
+
 **Always update CLAUDE.md when finishing updates.** After implementing a backlog item or making significant changes, mark the item as done in the Backlog section and update any affected documentation (project structure, key patterns, etc.) before committing.
 
 **Before every `git push`, ask the user what version number to use** and update `CFBundleShortVersionString` in `Sources/BG3MacModManager/Info.plist` accordingly. Do not push without confirming the version.

--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -122,6 +122,7 @@ struct BG3MacModManagerApp: App {
     private func importModFromPanel() {
         let panel = NSOpenPanel()
         panel.title = "Import Mod"
+        panel.prompt = "Import"
         panel.allowedContentTypes = [
             .init(filenameExtension: "pak")!,
             .init(filenameExtension: "zip")!,

--- a/Sources/BG3MacModManager/Views/HelpView.swift
+++ b/Sources/BG3MacModManager/Views/HelpView.swift
@@ -454,7 +454,7 @@ struct HelpView: View {
             helpHeading("Importing Mods")
             helpText("There are several ways to import mod files:")
             helpBulletList([
-                "File > Import Mod (Cmd+I) — Opens a file picker for .pak, .zip, .tar, and other archive formats. You can select a ZIP file directly without needing to open it first.",
+                "File > Import Mod (Cmd+I) — Opens a file picker for .pak, .zip, .tar, and other archive formats. Click \"Import\" to select a ZIP file directly — the app extracts the PAK inside automatically.",
                 "Drag and drop — Drag mod files directly onto the app window from Finder",
                 "Manual — Place .pak files directly in the Mods folder and click Refresh",
             ])
@@ -657,10 +657,15 @@ struct HelpView: View {
                 "Copy file paths from within the archive",
             ])
             helpText("""
-            You can open ZIP files directly — the inspector will extract the PAK inside \
-            automatically. If a ZIP contains multiple PAK files, you will be prompted to choose \
-            which one to inspect. Any info.json found alongside the PAK in the ZIP is available \
-            via the \"View info.json (ZIP)\" quick action button.
+            Use \"Select File...\" to pick a .pak or .zip file. ZIP files are opened automatically \
+            — the inspector extracts the PAK inside. If a ZIP contains multiple PAK files, you \
+            will be prompted to choose which one to inspect. Any info.json found alongside the PAK \
+            in the ZIP is available via the \"View info.json (ZIP)\" quick action button.
+            """)
+            helpText("""
+            Use \"Browse ZIP...\" to navigate inside a ZIP archive and select a specific .pak file \
+            directly. This is useful when a ZIP contains multiple PAKs and you want to pick one \
+            without the automatic extraction step.
             """)
             helpText("""
             Right-click any file in the list to view its contents or copy its path. This is useful \


### PR DESCRIPTION
PAK Inspector now has two file picker buttons:
- "Select File..." (prompt=Select) picks ZIPs as files for auto-extraction
- "Browse ZIP..." (prompt=Open, treatsFilePackagesAsDirectories=true) lets users navigate into ZIPs to pick a specific PAK

Import Mod panel now uses prompt="Import" so the action button selects ZIP files instead of navigating into them.

Also adds clarifying-questions guidance to CLAUDE.md workflow section.

https://claude.ai/code/session_011QypR5H1Szq2onDBmvDiFt