### PR TITLE
Replace NSOpenPanel with custom file picker for ZIP-as-file selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Sources/BG3MacModManager/
   Models/       - Data models (ModModel, ModCategory, NexusUpdateInfo, etc.)
   Services/     - Business logic (ModService, LaunchService, ModNotesService, NexusAPIService, NexusURLImportService, etc.)
   Utilities/    - Helpers (FileLocations, etc.)
-  Views/        - SwiftUI views (ContentView, ModListView, NexusURLImportView, etc.)
+  Views/        - SwiftUI views (ContentView, ModListView, ModFilePickerView, NexusURLImportView, etc.)
 Tests/BG3MacModManagerTests/
   TestHelpers.swift            - Factory functions (makeModInfo, makeDependency, makeSEStatus)
   Version64Tests.swift         - Version64 model tests
@@ -79,7 +79,7 @@ Prioritized feature and UX improvements organized by tier. Each item includes a 
 | 2.1 | Undo/Redo for Load Order | M | **Done** | Snapshot `(activeMods, inactiveMods)` before each mutation; support Cmd+Z / Cmd+Shift+Z. | `AppState.swift`, `BG3MacModManagerApp.swift` |
 | 2.2 | Profile Load Missing Mods Report | M | **Done** | When loading a profile, show a summary dialog of matched vs. missing mods with Nexus URLs. Reuse `ImportSummaryView`. | `AppState.swift`, `ContentView.swift`, `ImportSummaryView.swift` |
 | 2.3 | Inactive Mods Sorting Options | S–M | **Done** | Sort picker for inactive section: by name, author, category, file date, or file size. Persistent via @AppStorage. | `ModListView.swift` |
-| 2.4 | PAK Inspector Tool | M | **Done** | New tool under "Tools" sidebar to inspect any PAK or ZIP file's internal listing, meta.lsx, and info.json. Accepts ZIP archives containing PAKs with multi-PAK picker and ZIP-level info.json viewing. Uses existing `PakReader` and `ArchiveService`. | `PakInspectorView.swift`, `ContentView.swift`, `PakReader.swift` |
+| 2.4 | PAK Inspector Tool | M | **Done** | New tool under "Tools" sidebar to inspect any PAK or ZIP file's internal listing, meta.lsx, and info.json. Accepts ZIP archives containing PAKs with multi-PAK picker and ZIP-level info.json viewing. Uses custom `ModFilePickerView` for ZIP-as-file selection (bypasses macOS NSOpenPanel ZIP navigation), existing `PakReader` and `ArchiveService`. | `PakInspectorView.swift`, `ModFilePickerView.swift`, `ContentView.swift`, `PakReader.swift` |
 | 2.5 | Positional Drag from Inactive to Active | M | **Done** | Dragging an inactive mod into the active list inserts at the drop position via `.onInsert`. Falls back to append when filters are active. | `ModListView.swift`, `AppState.swift` |
 | 2.6 | Advanced Filter Popover | M | **Done** | Filter button in category bar with popover for: SE required, has warnings, metadata source. Badge shows active filter count. | `ModListView.swift` |
 | 2.7 | Profile Renaming and Updating | M | **Done** | "Rename" and "Update" (overwrite with current load order) actions on profile rows. | `ProfileManagerView.swift`, `ProfileService.swift`, `AppState.swift` |

--- a/Sources/BG3MacModManager/App/AppState.swift
+++ b/Sources/BG3MacModManager/App/AppState.swift
@@ -70,6 +70,9 @@ final class AppState: ObservableObject {
     /// Whether to show the post-import activation prompt.
     @Published var showImportActivation: Bool = false
 
+    /// Whether to show the custom mod import file picker.
+    @Published var showModImportPicker: Bool = false
+
     /// Request to navigate to a specific sidebar tab (set by action buttons, consumed by ContentView).
     @Published var navigateToSidebarItem: String?
 

--- a/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
+++ b/Sources/BG3MacModManager/App/BG3MacModManagerApp.swift
@@ -120,18 +120,7 @@ struct BG3MacModManagerApp: App {
     }
 
     private func importModFromPanel() {
-        let panel = NSOpenPanel()
-        panel.title = "Import Mod"
-        panel.prompt = "Import"
-        panel.delegate = ImportModPanelDelegate.shared
-        panel.allowsMultipleSelection = true
-        panel.canChooseDirectories = false
-
-        if panel.runModal() == .OK, !panel.urls.isEmpty {
-            Task {
-                await appState.importMods(from: panel.urls)
-            }
-        }
+        appState.showModImportPicker = true
     }
 
     private func importFromSavePanel() {
@@ -177,24 +166,6 @@ struct BG3MacModManagerApp: App {
 }
 
 // MARK: - Unsaved Changes on Close/Quit
-
-/// Filters the Import Mod file picker to show only .pak and archive files.
-/// By not using allowedContentTypes, ZIPs remain opaque (non-browsable) in the panel.
-private class ImportModPanelDelegate: NSObject, NSOpenSavePanelDelegate {
-    static let shared = ImportModPanelDelegate()
-
-    private static let allowedExtensions: Set<String> = [
-        "pak", "zip", "tar", "gz", "tgz", "bz2", "xz",
-    ]
-
-    func panel(_ sender: Any, shouldEnable url: URL) -> Bool {
-        var isDir: ObjCBool = false
-        if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue {
-            return true
-        }
-        return Self.allowedExtensions.contains(url.pathExtension.lowercased())
-    }
-}
 
 /// Response from the unsaved changes confirmation alert.
 private enum UnsavedChangesResponse {

--- a/Sources/BG3MacModManager/Views/ContentView.swift
+++ b/Sources/BG3MacModManager/Views/ContentView.swift
@@ -125,6 +125,16 @@ struct ContentView: View {
             let names = appState.lastImportedMods.map(\.name).joined(separator: ", ")
             Text("\(appState.lastImportedMods.count) new mod(s) imported: \(names)\n\nWould you like to add them to your active load order?")
         }
+        .sheet(isPresented: $appState.showModImportPicker) {
+            ModFilePickerView(
+                title: "Import Mod",
+                prompt: "Import",
+                allowedExtensions: ["pak", "zip", "tar", "gz", "tgz", "bz2", "xz"],
+                allowsMultipleSelection: true
+            ) { urls in
+                Task { await appState.importMods(from: urls) }
+            }
+        }
         .confirmationDialog(
             "Permanently Delete Mod\(appState.modsToDelete.count == 1 ? "" : "s")?",
             isPresented: $appState.showDeleteModConfirmation,

--- a/Sources/BG3MacModManager/Views/HelpView.swift
+++ b/Sources/BG3MacModManager/Views/HelpView.swift
@@ -454,7 +454,7 @@ struct HelpView: View {
             helpHeading("Importing Mods")
             helpText("There are several ways to import mod files:")
             helpBulletList([
-                "File > Import Mod (Cmd+I) — Opens a file picker for .pak, .zip, .tar, and other archive formats. Click \"Import\" to select a ZIP file directly — the app extracts the PAK inside automatically.",
+                "File > Import Mod (Cmd+I) — Opens a file browser for .pak, .zip, .tar, and other archive formats. ZIP files are shown as regular files (not browsable). Select a ZIP and click \"Import\" — the app extracts the PAK inside automatically.",
                 "Drag and drop — Drag mod files directly onto the app window from Finder",
                 "Manual — Place .pak files directly in the Mods folder and click Refresh",
             ])
@@ -657,10 +657,12 @@ struct HelpView: View {
                 "Copy file paths from within the archive",
             ])
             helpText("""
-            Use \"Select File...\" to pick a .pak or .zip file. ZIP files are opened automatically \
-            — the inspector extracts the PAK inside. If a ZIP contains multiple PAK files, you \
-            will be prompted to choose which one to inspect. Any info.json found alongside the PAK \
-            in the ZIP is available via the \"View info.json (ZIP)\" quick action button.
+            Use \"Select File...\" to open a custom file browser where you can pick a .pak or .zip \
+            file. Unlike the standard macOS file dialog, ZIP files are treated as regular files — \
+            clicking a ZIP selects it (it will not open to show its contents). The inspector then \
+            automatically extracts the PAK inside. If a ZIP contains multiple PAK files, you will \
+            be prompted to choose which one to inspect. Any info.json found alongside the PAK in \
+            the ZIP is available via the \"View info.json (ZIP)\" quick action button.
             """)
             helpText("""
             Use \"Browse ZIP...\" to navigate inside a ZIP archive and select a specific .pak file \

--- a/Sources/BG3MacModManager/Views/ModFilePickerView.swift
+++ b/Sources/BG3MacModManager/Views/ModFilePickerView.swift
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import SwiftUI
+
+/// Custom file picker sheet that replaces NSOpenPanel for cases where ZIP files
+/// must be selectable as opaque files (not navigable). macOS NSOpenPanel treats
+/// ZIPs as transparent directories and no API can prevent browsing into them.
+struct ModFilePickerView: View {
+    /// Title shown at the top of the picker.
+    let title: String
+    /// Label for the confirm button ("Import" or "Select").
+    let prompt: String
+    /// File extensions to show (e.g. ["pak", "zip", "tar"]).
+    let allowedExtensions: Set<String>
+    /// Whether the user can select more than one file.
+    let allowsMultipleSelection: Bool
+    /// Called with the selected file URL(s) when the user confirms.
+    let onSelect: ([URL]) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("lastFilePickerDirectory") private var lastDirectory: String = ""
+
+    @State private var currentDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    @State private var contents: [FileItem] = []
+    @State private var selectedFiles: Set<URL> = []
+    @State private var errorMessage: String?
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            titleBar
+            Divider()
+            navigationBar
+            Divider()
+            fileList
+            Divider()
+            actionBar
+        }
+        .frame(minWidth: 600, idealWidth: 700, minHeight: 450, idealHeight: 550)
+        .onAppear {
+            if !lastDirectory.isEmpty,
+               FileManager.default.fileExists(atPath: lastDirectory) {
+                currentDirectory = URL(fileURLWithPath: lastDirectory)
+            } else {
+                let downloads = FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent("Downloads")
+                if FileManager.default.fileExists(atPath: downloads.path) {
+                    currentDirectory = downloads
+                }
+            }
+            loadDirectory()
+        }
+    }
+
+    // MARK: - Title Bar
+
+    private var titleBar: some View {
+        HStack {
+            Text(title)
+                .font(.headline)
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Navigation Bar
+
+    private var navigationBar: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                Button {
+                    navigateUp()
+                } label: {
+                    Image(systemName: "chevron.left")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(currentDirectory.path == "/")
+                .help("Go to parent directory")
+
+                Text(abbreviatedPath(currentDirectory))
+                    .font(.system(.body, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            // Quick-access buttons
+            HStack(spacing: 6) {
+                Text("Quick Access:")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                quickAccessButton("Downloads", systemImage: "arrow.down.circle",
+                                  url: FileManager.default.homeDirectoryForCurrentUser
+                                      .appendingPathComponent("Downloads"))
+                quickAccessButton("Desktop", systemImage: "menubar.dock.rectangle",
+                                  url: FileManager.default.homeDirectoryForCurrentUser
+                                      .appendingPathComponent("Desktop"))
+                quickAccessButton("Home", systemImage: "house",
+                                  url: FileManager.default.homeDirectoryForCurrentUser)
+                Spacer()
+            }
+            .padding(.horizontal)
+        }
+        .padding(.vertical, 6)
+    }
+
+    private func quickAccessButton(_ label: String, systemImage: String, url: URL) -> some View {
+        Button {
+            navigateTo(url)
+        } label: {
+            Label(label, systemImage: systemImage)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(!FileManager.default.fileExists(atPath: url.path))
+        .help("Go to \(label)")
+    }
+
+    // MARK: - File List
+
+    @ViewBuilder
+    private var fileList: some View {
+        if let error = errorMessage {
+            Spacer()
+            VStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 32))
+                    .foregroundStyle(.red)
+                Text(error)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding()
+            Spacer()
+        } else if contents.isEmpty {
+            Spacer()
+            VStack(spacing: 8) {
+                Image(systemName: "folder")
+                    .font(.system(size: 32))
+                    .foregroundStyle(.secondary)
+                Text("No matching files in this directory")
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        } else {
+            List {
+                ForEach(contents) { item in
+                    if item.isDirectory {
+                        directoryRow(item)
+                    } else {
+                        fileRow(item)
+                    }
+                }
+            }
+            .listStyle(.inset(alternatesRowBackgrounds: true))
+        }
+    }
+
+    private func directoryRow(_ item: FileItem) -> some View {
+        Button {
+            navigateTo(item.url)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "folder.fill")
+                    .foregroundStyle(.blue)
+                    .frame(width: 20)
+                Text(item.name)
+                    .lineLimit(1)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .foregroundStyle(.tertiary)
+                    .font(.caption)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func fileRow(_ item: FileItem) -> some View {
+        let isSelected = selectedFiles.contains(item.url)
+        return Button {
+            toggleSelection(item.url)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? .blue : .secondary)
+                    .frame(width: 20)
+                Image(systemName: iconForExtension(item.url.pathExtension.lowercased()))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16)
+                Text(item.name)
+                    .lineLimit(1)
+                Spacer()
+                Text(formatBytes(item.fileSize))
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                if let date = item.modDate {
+                    Text(formatDate(date))
+                        .foregroundStyle(.tertiary)
+                        .font(.caption)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+    }
+
+    // MARK: - Action Bar
+
+    private var actionBar: some View {
+        HStack {
+            Button("Cancel") {
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+            .help("Cancel file selection")
+
+            Spacer()
+
+            if !selectedFiles.isEmpty {
+                Text("\(selectedFiles.count) selected")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Button(prompt) {
+                lastDirectory = currentDirectory.path
+                onSelect(Array(selectedFiles))
+                dismiss()
+            }
+            .keyboardShortcut(.defaultAction)
+            .buttonStyle(.borderedProminent)
+            .disabled(selectedFiles.isEmpty)
+            .help("\(prompt) the selected file\(selectedFiles.count == 1 ? "" : "s")")
+        }
+        .padding()
+    }
+
+    // MARK: - Navigation
+
+    private func navigateTo(_ url: URL) {
+        currentDirectory = url
+        loadDirectory()
+    }
+
+    private func navigateUp() {
+        let parent = currentDirectory.deletingLastPathComponent()
+        if parent.path != currentDirectory.path {
+            currentDirectory = parent
+            loadDirectory()
+        }
+    }
+
+    // MARK: - Selection
+
+    private func toggleSelection(_ url: URL) {
+        if allowsMultipleSelection {
+            if selectedFiles.contains(url) {
+                selectedFiles.remove(url)
+            } else {
+                selectedFiles.insert(url)
+            }
+        } else {
+            // Single-select mode: toggle or replace
+            if selectedFiles.contains(url) {
+                selectedFiles.removeAll()
+            } else {
+                selectedFiles = [url]
+            }
+        }
+    }
+
+    // MARK: - Directory Loading
+
+    private func loadDirectory() {
+        selectedFiles.removeAll()
+        do {
+            let keys: Set<URLResourceKey> = [.isDirectoryKey, .fileSizeKey, .contentModificationDateKey]
+            let items = try FileManager.default.contentsOfDirectory(
+                at: currentDirectory,
+                includingPropertiesForKeys: Array(keys),
+                options: [.skipsHiddenFiles]
+            )
+            contents = items.compactMap { url -> FileItem? in
+                let values = try? url.resourceValues(forKeys: keys)
+                let isDir = values?.isDirectory ?? false
+                // Hide non-matching files (but always show directories)
+                if !isDir && !allowedExtensions.contains(url.pathExtension.lowercased()) {
+                    return nil
+                }
+                return FileItem(
+                    url: url,
+                    name: url.lastPathComponent,
+                    isDirectory: isDir,
+                    fileSize: Int64(values?.fileSize ?? 0),
+                    modDate: values?.contentModificationDate
+                )
+            }.sorted()
+            errorMessage = nil
+        } catch {
+            contents = []
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func abbreviatedPath(_ url: URL) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let path = url.path
+        if path.hasPrefix(home) {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+
+    private func iconForExtension(_ ext: String) -> String {
+        switch ext {
+        case "pak": return "doc.zipper"
+        case "zip": return "doc.zipper"
+        case "tar", "gz", "tgz", "bz2", "xz": return "archivebox"
+        default: return "doc"
+        }
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - FileItem
+
+extension ModFilePickerView {
+    struct FileItem: Identifiable, Comparable {
+        let url: URL
+        let name: String
+        let isDirectory: Bool
+        let fileSize: Int64
+        let modDate: Date?
+
+        var id: URL { url }
+
+        static func < (lhs: FileItem, rhs: FileItem) -> Bool {
+            // Directories first, then alphabetical by name (case-insensitive)
+            if lhs.isDirectory != rhs.isDirectory {
+                return lhs.isDirectory
+            }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+}


### PR DESCRIPTION
macOS NSOpenPanel treats ZIP files as transparent directories, making them navigable instead of selectable. This adds ModFilePickerView, a custom SwiftUI file browser sheet where ZIPs appear as regular selectable files. Used for Import Mod (Cmd+I) and PAK Inspector "Select File" — the "Browse ZIP" button retains NSOpenPanel for intentional ZIP navigation.

https://claude.ai/code/session_011QypR5H1Szq2onDBmvDiFt