### PR TITLE
Fix CSV header detection, URL validation, test fixtures, and CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Run tests
+        run: swift test
+
       - name: Install create-dmg
         run: brew install create-dmg
 

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
             dependencies: [
                 .product(name: "ZIPFoundation", package: "ZIPFoundation"),
             ],
-            path: "Sources/BG3MacModManager"
+            path: "Sources/BG3MacModManager",
+            exclude: ["Info.plist"]
         ),
         .testTarget(
             name: "BG3MacModManagerTests",

--- a/Tests/BG3MacModManagerTests/PakReaderTests.swift
+++ b/Tests/BG3MacModManagerTests/PakReaderTests.swift
@@ -66,8 +66,8 @@ final class PakReaderTests: XCTestCase {
         var data = Data([0x4C, 0x53, 0x50, 0x4B]) // "LSPK"
         // Version 99 as UInt32 little-endian
         data.append(contentsOf: [0x63, 0x00, 0x00, 0x00])
-        // Pad remaining header bytes (28 bytes)
-        data.append(Data(count: 28))
+        // Pad remaining header bytes (32 bytes to reach headerSize of 36)
+        data.append(Data(count: 32))
         let url = writeTempBinary(name: "bad_version.pak", data: data)
 
         XCTAssertThrowsError(try PakReader.listFiles(at: url)) { error in
@@ -88,7 +88,7 @@ final class PakReaderTests: XCTestCase {
         // Should fail on file list read, not on version check
         var data = Data([0x4C, 0x53, 0x50, 0x4B]) // "LSPK"
         data.append(contentsOf: [0x12, 0x00, 0x00, 0x00]) // version 18
-        data.append(Data(count: 28)) // rest of header zeroed
+        data.append(Data(count: 32)) // rest of header zeroed (4 + 32 = 36 = headerSize)
         let url = writeTempBinary(name: "v18.pak", data: data)
 
         XCTAssertThrowsError(try PakReader.listFiles(at: url)) { error in
@@ -131,7 +131,7 @@ final class PakReaderTests: XCTestCase {
     // MARK: - CompressionType Enum
 
     func testCompressionTypeNone() {
-        XCTAssertEqual(PakReader.CompressionType(rawValue: 0), .none)
+        XCTAssertEqual(PakReader.CompressionType(rawValue: 0), PakReader.CompressionType.none)
     }
 
     func testCompressionTypeZlib() {


### PR DESCRIPTION
## Summary
- **looksLikeHeader** now splits by separator and matches exact header names instead of substring search, fixing silent data loss when importing CSVs with mod names containing "mod", "name", "url", etc.
- **isNexusURL** validates host via `URLComponents` instead of `contains()`, preventing false positives from query strings or non-Nexus domains
- **PakReaderTests**: fixed header padding (28→32 bytes) so version validation runs before read errors; disambiguated `.none` vs `Optional.none`
- Added `swift test` step to release workflow before build/sign/notarize
- Excluded `Info.plist` from SPM target to silence build warning

## Test plan
- [ ] Verify `looksLikeHeader` correctly skips header rows like `"Name,URL"` while keeping data rows like `"ModA,https://..."`
- [ ] Verify `isNexusURL` accepts `https://www.nexusmods.com/...` and rejects `https://evil.com/?q=nexusmods.com`
- [ ] Verify PakReaderTests pass with corrected padding and explicit CompressionType
- [ ] Verify `swift test` runs clean (NexusURLImportServiceTests regressions resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)