### PR TITLE
Make service storage URLs injectable for test isolation

### DIFF
--- a/Sources/BG3MacModManager/Services/CategoryInferenceService.swift
+++ b/Sources/BG3MacModManager/Services/CategoryInferenceService.swift
@@ -45,16 +45,16 @@ final class CategoryInferenceService {
 
     private var userOverrides: [String: ModCategory] = [:]
 
-    private static var overridesURL: URL {
-        FileLocations.appSupportDirectory.appendingPathComponent("category_overrides.json")
-    }
+    private let overridesURL: URL
 
-    init() {
+    init(overridesURL: URL? = nil) {
+        self.overridesURL = overridesURL
+            ?? FileLocations.appSupportDirectory.appendingPathComponent("category_overrides.json")
         loadOverrides()
     }
 
     private func loadOverrides() {
-        guard let data = try? Data(contentsOf: Self.overridesURL),
+        guard let data = try? Data(contentsOf: overridesURL),
               let decoded = try? JSONDecoder().decode([String: ModCategory].self, from: data) else {
             return
         }
@@ -63,9 +63,9 @@ final class CategoryInferenceService {
 
     private func saveOverrides() {
         do {
-            try FileLocations.ensureDirectoryExists(FileLocations.appSupportDirectory)
+            try FileLocations.ensureDirectoryExists(overridesURL.deletingLastPathComponent())
             let data = try JSONEncoder().encode(userOverrides)
-            try data.write(to: Self.overridesURL, options: .atomic)
+            try data.write(to: overridesURL, options: .atomic)
         } catch {
             // Non-fatal: overrides just won't persist
         }

--- a/Sources/BG3MacModManager/Services/ModNotesService.swift
+++ b/Sources/BG3MacModManager/Services/ModNotesService.swift
@@ -32,16 +32,16 @@ final class ModNotesService {
 
     private var notes: [String: String] = [:]
 
-    private static var storageURL: URL {
-        FileLocations.appSupportDirectory.appendingPathComponent("mod_notes.json")
-    }
+    private let storageURL: URL
 
-    init() {
+    init(storageURL: URL? = nil) {
+        self.storageURL = storageURL
+            ?? FileLocations.appSupportDirectory.appendingPathComponent("mod_notes.json")
         load()
     }
 
     private func load() {
-        guard let data = try? Data(contentsOf: Self.storageURL),
+        guard let data = try? Data(contentsOf: storageURL),
               let decoded = try? JSONDecoder().decode([String: String].self, from: data) else {
             return
         }
@@ -50,9 +50,9 @@ final class ModNotesService {
 
     private func save() {
         do {
-            try FileLocations.ensureDirectoryExists(FileLocations.appSupportDirectory)
+            try FileLocations.ensureDirectoryExists(storageURL.deletingLastPathComponent())
             let data = try JSONEncoder().encode(notes)
-            try data.write(to: Self.storageURL, options: .atomic)
+            try data.write(to: storageURL, options: .atomic)
         } catch {
             // Non-fatal: notes just won't persist
         }


### PR DESCRIPTION
## Summary
- `CategoryInferenceService` and `ModNotesService` now accept an optional storage URL parameter, defaulting to the existing app support paths
- Tests use unique temp files per run via `setUp()`/`tearDown()`, eliminating coupling to local machine state
- Added persistence round-trip tests for both services

## Test plan
- [ ] Existing tests pass with isolated temp storage (no dependency on local app data)
- [ ] `testOverridePersistsAcrossInstances` verifies write-then-read across service instances
- [ ] `testNotesPersistAcrossInstances` verifies the same for mod notes
- [ ] Production behavior unchanged (default `init()` still uses app support paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)